### PR TITLE
Fix stamp conflict

### DIFF
--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -40,7 +40,7 @@ SCRIPTS = [
 
 LOG_DIR = Path("logs"); LOG_DIR.mkdir(exist_ok=True)
 
-def stamp():
+def iso_stamp() -> str:
     """Return current local time in ISO-8601 to-the-second."""
     return datetime.now().isoformat(timespec="seconds")
 
@@ -51,7 +51,7 @@ def launch(name, cmd):
     )
 
 procs = {name: launch(name, cmd) for name, cmd in SCRIPTS}
-print(f"[{stamp()}] 🚀  Started {len(procs)} child processes.")
+print(f"[{iso_stamp()}] 🚀  Started {len(procs)} child processes.")
 
 def stamp(): return datetime.now().strftime("%H:%M:%S")
 


### PR DESCRIPTION
## Summary
- fix duplicate `stamp` function in `race_data_runner`
- use a distinct ISO timestamp for startup log message

## Testing
- `python -m py_compile ai_standings_logger.py pitstop_logger_enhanced.py race_data_runner.py standings_sorter.py`
- `flake8 --max-line-length=100 .`
- `mypy ai_standings_logger.py pitstop_logger_enhanced.py standings_sorter.py race_data_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb2c32550832abe16825e190b8cec