### PR TITLE
Fix race logger startup without dependencies

### DIFF
--- a/pitstop_logger_enhanced.py
+++ b/pitstop_logger_enhanced.py
@@ -1,4 +1,8 @@
-import irsdk, csv, time, pandas as pd
+import irsdk, csv, time
+try:
+    import pandas as pd
+except Exception:
+    pd = None
 from datetime import datetime
 
 CSV_FILE     = "pitstop_log.csv"
@@ -21,6 +25,8 @@ def minsec(sec):
     return f"{m}:{s:02d}"
 
 def write_overlay(csv_path, html_path=OVERLAY_FILE):
+    if pd is None:
+        return
     df = pd.read_csv(csv_path)
     latest = (df.sort_values("Stint End Timestamp", ascending=False)
                 .drop_duplicates("CarIdx")
@@ -101,7 +107,8 @@ while True:
                         print(f"[{iso_now()}] STINT END – "
                             f"{team} / {drv}: {row[-1]} laps, {row[-2]}.")
 
-                        write_overlay(CSV_FILE)
+                        if pd is not None:
+                            write_overlay(CSV_FILE)
                         stint[idx] = {"on_pit": True}     # wait for exit
 
                     # pit exit → new stint

--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -3,9 +3,18 @@ import subprocess, signal, sys, time, os, threading, shutil
 import csv, itertools
 from pathlib import Path
 from datetime import datetime
-from colorama import init as _init, Fore, Style
+try:
+    from colorama import init as _init, Fore, Style
+    _init(autoreset=True)
+except Exception:  # colorama not installed
+    class _Dummy:
+        def __getattr__(self, _):
+            return ""
+
+    Fore = Style = _Dummy()
+    def _init(*args, **kwargs):
+        pass
 from collections import defaultdict
-_init(autoreset=True)          # initialise colourama (harmless on *nix)
 
 PITLOG = Path("pitstop_log.csv")   # same name the logger writes
 STANDINGS_LOG = Path("standings_log.csv")   # the file ai_standings_logger writes

--- a/standings_sorter.py
+++ b/standings_sorter.py
@@ -1,4 +1,7 @@
-import pandas as pd
+try:
+    import pandas as pd
+except Exception:
+    pd = None
 import time
 
 INPUT  = "standings_log.csv"
@@ -13,6 +16,9 @@ def class_name(cid: str) -> str:
     return CAR_CLASS_MAP.get(str(cid), f"Class {cid}")
 
 def sort_and_write():
+    if pd is None:
+        print("[ERR] pandas not installed – standings sorter disabled")
+        return
     try:
         df = pd.read_csv(INPUT)
 


### PR DESCRIPTION
## Summary
- avoid crash in `race_data_runner.py` when `colorama` is missing
- handle missing pandas in `pitstop_logger_enhanced.py`
- gracefully skip standings sorting if pandas is missing

## Testing
- `python -m py_compile race_gui.py race_data_runner.py ai_standings_logger.py pitstop_logger_enhanced.py standings_sorter.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc83c54c0832a9f574e367ee63db7