### PR TITLE
Fix path for runner when using the GUI EXE

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ pip install pyinstaller
 pyinstaller --onefile race_gui.py
 ```
 
-The resulting `dist/race_gui.exe` will include all scripts and can be run without Python installed.
+The resulting `dist/race_gui.exe` can be distributed by itself.  When launched from
+inside the `dist` folder it looks for `race_data_runner.py` in the parent directory
+(the project root), so keep the default folder structure or adjust the path in
+`race_gui.py` if you move the executable elsewhere.
 
 ### Running the executable
 

--- a/race_gui.py
+++ b/race_gui.py
@@ -6,6 +6,7 @@ import threading
 import time
 import os
 import shutil
+import sys
 from pathlib import Path
 from queue import Queue, Empty
 try:
@@ -60,8 +61,11 @@ class RaceLoggerGUI:
         if self.proc:
             messagebox.showinfo("Logger", "Already running")
             return
+        runner = Path(sys.argv[0]).resolve().parent / "race_data_runner.py"
+        if not runner.exists():
+            runner = Path(sys.argv[0]).resolve().parent.parent / "race_data_runner.py"
         self.proc = subprocess.Popen(
-            ["python", "race_data_runner.py"],
+            ["python", str(runner)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,


### PR DESCRIPTION
## Summary
- spawn race_data_runner.py using an absolute path
- document where the EXE looks for the python scripts

## Testing
- `python -m py_compile race_gui.py race_data_runner.py ai_standings_logger.py pitstop_logger_enhanced.py standings_sorter.py`

------
https://chatgpt.com/codex/tasks/task_e_683fd17de74c832a8b7f7dde7f2694e5