### PR TITLE
Fix unicode printing on Windows

### DIFF
--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from datetime import datetime
 try:
     from colorama import init as _init, Fore, Style
+    try:
+        from colorama import just_fix_windows_console
+        just_fix_windows_console()
+    except Exception:
+        pass
     _init(autoreset=True)
 except Exception:  # colorama not installed
     class _Dummy:


### PR DESCRIPTION
## Summary
- call `colorama.just_fix_windows_console` before init so emoji characters print correctly

## Testing
- `python -m py_compile race_data_runner.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683fd3b48b54832a8c5f813f16f5ea72