### PR TITLE
Fix log paths when running from dist

### DIFF
--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -3,6 +3,10 @@ import subprocess, signal, sys, time, os, threading, shutil
 import csv, itertools
 from pathlib import Path
 from datetime import datetime
+
+# Ensure all relative paths resolve to the directory this file lives in
+BASE_DIR = Path(__file__).resolve().parent
+os.chdir(BASE_DIR)
 try:
     from colorama import init as _init, Fore, Style
     try:


### PR DESCRIPTION
## Summary
- ensure race_data_runner.py changes into its own directory before launching sub-scripts

## Testing
- `python -m py_compile race_data_runner.py ai_standings_logger.py pitstop_logger_enhanced.py standings_sorter.py race_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_683fd510df28832a83a49f770f1bb699