### PR TITLE
Fix GUI subprocess encoding

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -70,6 +70,8 @@ class RaceLoggerGUI:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            encoding="utf-8",
+            errors="replace",
         )
         self.output_thread = threading.Thread(target=self.read_output, daemon=True)
         self.output_thread.start()


### PR DESCRIPTION
## Summary
- ensure the GUI decodes output from `race_data_runner.py` as UTF-8

## Testing
- `python -m py_compile race_gui.py race_data_runner.py ai_standings_logger.py pitstop_logger_enhanced.py standings_sorter.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-irsdk)*

------
https://chatgpt.com/codex/tasks/task_e_683fda8741cc832a8ca10892fcbe672c