### PR TITLE
Enable driver swap log viewing

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -129,7 +129,11 @@ class RaceLoggerGUI:
 
     def view_logs(self):
         log_dir = Path("logs")
-        files = [f.name for f in log_dir.glob("*.txt")]
+        file_map = {f.name: f for f in log_dir.glob("*.txt")}
+        swap_file = Path("driver_swaps.csv")
+        if swap_file.exists():
+            file_map[swap_file.name] = swap_file
+        files = list(file_map.keys())
         if not files:
             messagebox.showinfo("Logs", "No log files found")
             return
@@ -145,7 +149,7 @@ class RaceLoggerGUI:
         txt.pack(fill="both", expand=True, padx=5, pady=5)
 
         def load(event=None):
-            path = log_dir / sel.get()
+            path = file_map[sel.get()]
             try:
                 with open(path, "r", encoding="utf-8", errors="ignore") as fh:
                     content = fh.read()


### PR DESCRIPTION
## Summary
- include `driver_swaps.csv` in the GUI log viewer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdbb6b350832abfc92e9182c355c0