### PR TITLE
Add Quit menu to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Logos and spec maps under `Logos/` and `SpecMaps/` contain the Final Fantasy XIV
 ## GUI
 
 A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  A "View Logs…" button opens the latest text logs right inside the program.  If the optional `openai` package is installed and an `OPENAI_API_KEY` environment variable is set, the GUI can send the logs to ChatGPT and store the resulting analysis in a text file.
+The window also provides a simple *File* menu with a *Quit* action to close the application.
 
 Run it with:
 

--- a/race_gui.py
+++ b/race_gui.py
@@ -33,6 +33,12 @@ class RaceLoggerGUI:
         self.log_queue: Queue[str] = Queue()
         self.output_thread = None
 
+        menubar = tk.Menu(root)
+        file_menu = tk.Menu(menubar, tearoff=0)
+        file_menu.add_command(label="Quit", command=self.on_close)
+        menubar.add_cascade(label="File", menu=file_menu)
+        root.config(menu=menubar)
+
         frm = ttk.Frame(root, padding=10)
         frm.grid()
 


### PR DESCRIPTION
## Summary
- add a simple menu with a Quit action to `race_gui.py`
- note the new Quit menu in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdbf20024832a92992165ab8f9fd1