### PR TITLE
Fix setup script failure by adding placeholder package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "eec-utils",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eec-utils",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "eec-utils",
+  "version": "1.0.0",
+  "description": "Placeholder package to satisfy npm install.",
+  "private": true,
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add an empty `package.json` so that `npm install` succeeds

## Testing
- `npm install`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fdd3f9f5c832a906493403be13164