### PR TITLE
Fix standings viewer path

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -174,7 +174,12 @@ class RaceLoggerGUI:
         load()
 
     def view_standings(self):
-        csv_path = Path("sorted_standings.csv")
+        base = Path(sys.argv[0]).resolve().parent
+        csv_path = base / "sorted_standings.csv"
+        if not csv_path.exists():
+            csv_path = base.parent / "sorted_standings.csv"
+        if not csv_path.exists():
+            csv_path = Path("sorted_standings.csv")
         if not csv_path.exists():
             messagebox.showinfo("Standings", "No standings file found")
             return


### PR DESCRIPTION
## Summary
- handle sorted_standings.csv path more robustly in GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fe24eda18832abb2d7fff140a68fa