### PR TITLE
Fix Stop Logging

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 from tkinter.scrolledtext import ScrolledText
 import subprocess
+import signal
 import threading
 import time
 import os
@@ -89,11 +90,16 @@ class RaceLoggerGUI:
     def stop_logging(self):
         if not self.proc:
             return
-        self.proc.terminate()
         try:
+            # Gracefully stop the runner so it can terminate child processes
+            self.proc.send_signal(signal.SIGINT)
             self.proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            self.proc.kill()
+            # Fallback to force termination if it doesn't exit
+            self.proc.terminate()
+            self.proc.wait(timeout=5)
+        except Exception:
+            pass
         self.proc = None
         self.output_thread = None
         self.start_btn.config(state="normal")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+import signal
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from race_gui import RaceLoggerGUI
+
+class DummyProc:
+    def __init__(self):
+        self.signals = []
+        self.waits = 0
+        self.terminated = False
+    def send_signal(self, sig):
+        self.signals.append(sig)
+    def wait(self, timeout=None):
+        self.waits += 1
+    def terminate(self):
+        self.terminated = True
+    def kill(self):
+        self.killed = True
+
+class DummyButton:
+    def config(self, **kwargs):
+        pass
+
+def test_stop_logging_sends_sigint():
+    gui = types.SimpleNamespace(
+        proc=DummyProc(),
+        output_thread=object(),
+        start_btn=DummyButton(),
+        stop_btn=DummyButton()
+    )
+    p = gui.proc
+    RaceLoggerGUI.stop_logging(gui)
+    assert signal.SIGINT in p.signals
+    assert p.waits == 1
+    assert p.terminated is False
+    assert gui.output_thread is None
+


### PR DESCRIPTION
## Summary
- send SIGINT when stopping logging so race_data_runner can clean up
- add regression test for stop_logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe59ce5d4832a828ed849af5f6cc0