### PR TITLE
Add CSV viewer tab in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This creates CSV log files in the repository directory and writes console output
 Logos and spec maps under `Logos/` and `SpecMaps/` contain the Final Fantasy XIV themed assets used for the championship.
 
 ## GUI
-A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  A "View Logs…" button opens the latest text logs right inside the program.  If the optional `openai` package is installed and an `OPENAI_API_KEY` environment variable is set, the GUI can send the logs to ChatGPT and store the resulting analysis in a text file.
+A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  The window now includes tabs to view the `pitstop_log.csv`, `driver_swaps.csv` and `standings_log.csv` files directly.  If the optional `openai` package is installed and an `OPENAI_API_KEY` environment variable is set, the GUI can send the logs to ChatGPT and store the resulting analysis in a text file.
 The window also provides a simple *File* menu with a *Quit* action to close the application.
 
 Run it with:


### PR DESCRIPTION
## Summary
- replace old view logs button with built-in CSV viewer tabs
- show pit stops, driver swaps and standings log inside the GUI
- update README with new instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683feab9e97c832ab34f077986519261