### PR TITLE
Fix standings view to skip non-racing cars

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -41,6 +41,27 @@ ANSI_COLOUR_MAP = {
     "37": "white", "97": "white",
 }
 
+
+def filter_rows(rows):
+    """Filter out non-racing entries from standings rows."""
+    filtered = []
+    for r in rows:
+        driver = r.get("Driver", "")
+        try:
+            pos = int(r.get("Pos", 0))
+        except Exception:
+            pos = 0
+        try:
+            laps = float(r.get("Laps", 0))
+        except Exception:
+            laps = 0.0
+        if driver in {"Pace Car", "Lily Bowling"}:
+            continue
+        if pos <= 0 or laps <= 0:
+            continue
+        filtered.append(r)
+    return filtered
+
 class RaceLoggerGUI:
     def __init__(self, root: tk.Tk):
         self.root = root
@@ -278,6 +299,7 @@ class RaceLoggerGUI:
             try:
                 with csv_path.open("r", newline="", encoding="utf-8") as f:
                     rows = list(csv.DictReader(f))
+                rows = filter_rows(rows)
                 rows.sort(key=lambda r: (r.get("Class", ""),
                                          int(r.get("Class Pos", 0))))
                 for r in rows:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,7 +4,7 @@ import signal
 import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from race_gui import RaceLoggerGUI
+from race_gui import RaceLoggerGUI, filter_rows
 
 class DummyProc:
     def __init__(self):
@@ -37,4 +37,16 @@ def test_stop_logging_sends_sigint():
     assert p.waits == 1
     assert p.terminated is False
     assert gui.output_thread is None
+
+
+def test_filter_rows_removes_pace_and_zero_lap_entries():
+    rows = [
+        {"Driver": "DriverA", "Pos": "1", "Laps": "5"},
+        {"Driver": "Pace Car", "Pos": "1", "Laps": "5"},
+        {"Driver": "DriverB", "Pos": "0", "Laps": "2"},
+        {"Driver": "DriverC", "Pos": "3", "Laps": "0"},
+    ]
+    filtered = filter_rows(rows)
+    assert len(filtered) == 1
+    assert filtered[0]["Driver"] == "DriverA"
 


### PR DESCRIPTION
## Summary
- hide pace car and 0-lap entries in standings view
- expose filtering helper for tests
- test filtering logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683feeac5a80832a815e21e571999db8