### PR TITLE
Fix Tk font name quoting causing crash

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -146,7 +146,8 @@ class RaceLoggerGUI:
         self.fg = "#e7e7ff"
         accent = "#3c445c"
         self.root.configure(bg=self.bg)
-        self.root.option_add("*Font", "Segoe UI 10")
+        # Escaped font family to avoid TclError when family name has spaces
+        self.root.option_add("*Font", "{Segoe UI} 10")
         style.configure("TFrame", background=self.bg)
         style.configure("TLabel", background=self.bg, foreground=self.fg)
         style.configure("TButton", background="#2b3249", foreground=self.fg, padding=6)


### PR DESCRIPTION
## Summary
- wrap the font family name in braces so spaces are handled correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff2f08cf4832ab74a21740d9e665a