### PR TITLE
Fix driver times path

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -342,7 +342,12 @@ class RaceLoggerGUI:
         load()
 
     def view_driver_times(self):
-        csv_path = Path("driver_times.csv")
+        base = Path(sys.argv[0]).resolve().parent
+        csv_path = base / "driver_times.csv"
+        if not csv_path.exists():
+            csv_path = base.parent / "driver_times.csv"
+        if not csv_path.exists():
+            csv_path = Path("driver_times.csv")
         if not csv_path.exists():
             messagebox.showinfo("Driver Times", "No driver time file found")
             return


### PR DESCRIPTION
## Summary
- ensure the GUI looks for `driver_times.csv` in the same search order as the other CSV loaders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff4deaddc832ab79de4e0b544fd06