### PR TITLE
Improve standings grouping by class

### DIFF
--- a/standings.css
+++ b/standings.css
@@ -52,6 +52,29 @@ tr.class-gt3.leader td {
     box-shadow: 0 0 8px #e8bc47;
 }
 
+/* Group header rows per class */
+tr.group-header td {
+    font-weight: bold;
+    text-align: left;
+    padding-top: 0.6em;
+    font-size: 1.2em;
+}
+
+tr.class-hypercar.group-header td {
+    background: linear-gradient(90deg, #174fa3 60%, #1f3262 100%);
+    color: #fff;
+}
+
+tr.class-p2.group-header td {
+    background: linear-gradient(90deg, #24c080 60%, #135c41 100%);
+    color: #fff;
+}
+
+tr.class-gt3.group-header td {
+    background: linear-gradient(90deg, #f3c46a 60%, #917737 100%);
+    color: #232323;
+}
+
 #standingsTable {
     border-collapse: collapse;
     width: 100%;

--- a/standings.js
+++ b/standings.js
@@ -79,35 +79,44 @@ const CLASS_ICON = {
     "GT3":      "🟩"
 };
 
+let lastClass = null;
 for (const row of dataRows) {
     const tr = document.createElement('tr');
-    // Add FFXIV class color (ensure lower case key matches CSS)
     const rawClass = row[colIdx.class];
     let classKey = '';
     let classDisplay = rawClass;
     if (CLASS_MAP[rawClass]) {
         classKey = CLASS_MAP[rawClass].display.toLowerCase();
         classDisplay = CLASS_MAP[rawClass].display;
-        tr.classList.add(`class-${classKey}`);
     }
-    // Highlight class leaders
-    if (row[colIdx.classPos] === "1") tr.classList.add("leader");
+
+    if (classKey !== lastClass) {
+        lastClass = classKey;
+        const headerTr = document.createElement('tr');
+        headerTr.classList.add(`class-${classKey}`, 'group-header');
+        const headerTd = document.createElement('td');
+        headerTd.colSpan = headers.length;
+        headerTd.textContent = classDisplay;
+        headerTr.appendChild(headerTd);
+        tbody.appendChild(headerTr);
+    }
+
+    tr.classList.add(`class-${classKey}`);
+    if (row[colIdx.classPos] === "1") tr.classList.add('leader');
 
     [
         colIdx.driver,
-        null, // For class, handled below
+        null,
         colIdx.pos, colIdx.classPos,
         colIdx.laps, colIdx.pits, colIdx.avgLap,
         colIdx.bestLap, colIdx.lastLap, colIdx.inPit
     ].forEach((idx, i) => {
         const td = document.createElement('td');
         if (i === 1) {
-            // Add class icon
-            let icon = "";
+            let icon = '';
             if (CLASS_ICON[classDisplay]) icon = `<span class="class-icon">${CLASS_ICON[classDisplay]}</span>`;
             td.innerHTML = icon + classDisplay;
-        }
-        else if (idx !== null) {
+        } else if (idx !== null) {
             const val = row[idx];
             const num = parseFloat(val);
             td.textContent = isNaN(num) ? val : formatNumber(val);


### PR DESCRIPTION
## Summary
- group the standings table rows by class
- style group headers by class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff58cbe64832ab91b594a3e824d3a