### PR TITLE
Sort standings classes by best position

### DIFF
--- a/standings_sorter.py
+++ b/standings_sorter.py
@@ -55,7 +55,13 @@ def sort_and_write():
         cols = ["Team", "Driver", "Class", "Pos", "Class Pos",
                 "Laps", "Pits", "Avg Lap", "Best Lap", "Last Lap", "In Pit"]
 
-        latest.sort_values(by=["Class", "Pos"]).to_csv(OUTPUT, columns=cols, index=False)
+        # sort classes by the best overall position so faster classes appear first
+        order = latest.groupby("Class")["Pos"].min().sort_values().index
+        class_order = {c: i for i, c in enumerate(order)}
+        latest["_cls_order"] = latest["Class"].map(class_order)
+        latest.sort_values(by=["_cls_order", "Pos"], inplace=True)
+        latest.drop(columns="_cls_order", inplace=True)
+        latest.to_csv(OUTPUT, columns=cols, index=False)
         print("[OK] standings written →", OUTPUT)
     except Exception as e:
         print("[ERR]", e)

--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -27,9 +27,9 @@ def test_sort_and_write(tmp_path, monkeypatch):
         "PitCount",
     ]
     rows = [
-        ["2021-01-01T00:00:00", 0, "TeamA", "DriverA", "2708", 1, 1, 10, 60, 61, False, 1],
-        ["2021-01-01T00:00:05", 1, "TeamB", "DriverB", "4074", 2, 1, 10, 55, 56, False, 0],
-        ["2021-01-01T00:00:10", 0, "TeamA", "DriverA", "2708", 1, 1, 11, 60, 62, False, 1],
+        ["2021-01-01T00:00:00", 0, "TeamA", "DriverA", "2708", 2, 1, 10, 60, 61, False, 1],
+        ["2021-01-01T00:00:05", 1, "TeamB", "DriverB", "4074", 1, 1, 10, 55, 56, False, 0],
+        ["2021-01-01T00:00:10", 0, "TeamA", "DriverA", "2708", 2, 1, 11, 60, 62, False, 1],
     ]
     with open(inp, "w", newline="") as f:
         wr = csv.writer(f)
@@ -42,8 +42,8 @@ def test_sort_and_write(tmp_path, monkeypatch):
         out_rows = list(csv.DictReader(f))
 
     assert len(out_rows) == 2
-    assert out_rows[0]["Team"] == "TeamA"
-    assert out_rows[0]["Class"] == "GT3"
-    assert out_rows[0]["Avg Lap"] == "61.5"
-    assert out_rows[1]["Team"] == "TeamB"
-    assert out_rows[1]["Class"] == "Hypercar"
+    assert out_rows[0]["Team"] == "TeamB"
+    assert out_rows[0]["Class"] == "Hypercar"
+    assert out_rows[1]["Team"] == "TeamA"
+    assert out_rows[1]["Class"] == "GT3"
+    assert out_rows[1]["Avg Lap"] == "61.5"


### PR DESCRIPTION
## Summary
- sort classes dynamically by best overall position when writing standings
- adjust overlay script to order classes by their fastest car
- update sorter tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff5df306c832a9458a2e87536ab79