### PR TITLE
Generalize class color handling

### DIFF
--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -35,11 +35,13 @@ STANDINGS_LOG = Path("standings_log.csv")   # the file ai_standings_logger write
 DRIVER_SWAP_CSV = Path("driver_swaps.csv")
 
 
-# A finite palette of bright-ish colours (skip yellow – hard to read on white terminals)
+# Ordered palette for class colours (fastest → slowest)
 _PALETTE = [
-    Fore.MAGENTA, Fore.CYAN, Fore.GREEN,
-    Fore.BLUE, Fore.RED, Fore.LIGHTMAGENTA_EX,
-    Fore.LIGHTCYAN_EX, Fore.LIGHTGREEN_EX, Fore.LIGHTBLUE_EX,
+    Style.BRIGHT + Fore.YELLOW,
+    Fore.BLUE,
+    Fore.RED,
+    Fore.GREEN,
+    Fore.MAGENTA,
 ]
 CLASS_COLOUR: dict[str, str] = {}          # filled on the fly
 

--- a/standings.css
+++ b/standings.css
@@ -19,19 +19,29 @@ body {
     margin: 0 0.2em;
 }
 
-tr.class-hypercar td {
+tr.class-1 td {
+    background: linear-gradient(90deg, #f3e36b 60%, #b59f00 100%);
+    color: #232323;
+}
+
+tr.class-2 td {
     background: linear-gradient(90deg, #174fa3 60%, #1f3262 100%);
     color: #fff;
 }
 
-tr.class-p2 td {
+tr.class-3 td {
+    background: linear-gradient(90deg, #d9534f 60%, #7a2624 100%);
+    color: #fff;
+}
+
+tr.class-4 td {
     background: linear-gradient(90deg, #24c080 60%, #135c41 100%);
     color: #fff;
 }
 
-tr.class-gt3 td {
-    background: linear-gradient(90deg, #f3c46a 60%, #917737 100%);
-    color: #232323;
+tr.class-5 td {
+    background: linear-gradient(90deg, #d878d8 60%, #773977 100%);
+    color: #fff;
 }
 
 tr.leader td {
@@ -40,16 +50,24 @@ tr.leader td {
     box-shadow: 0 0 10px 2px gold;
 }
 
-tr.class-hypercar.leader td {
+tr.class-1.leader td {
+    box-shadow: 0 0 8px #e5c72f;
+}
+
+tr.class-2.leader td {
     box-shadow: 0 0 8px #60a3fa;
 }
 
-tr.class-p2.leader td {
+tr.class-3.leader td {
+    box-shadow: 0 0 8px #d24b4e;
+}
+
+tr.class-4.leader td {
     box-shadow: 0 0 8px #24c080;
 }
 
-tr.class-gt3.leader td {
-    box-shadow: 0 0 8px #e8bc47;
+tr.class-5.leader td {
+    box-shadow: 0 0 8px #c84bc7;
 }
 
 /* Group header rows per class */
@@ -60,19 +78,29 @@ tr.group-header td {
     font-size: 1.2em;
 }
 
-tr.class-hypercar.group-header td {
+tr.class-1.group-header td {
+    background: linear-gradient(90deg, #f3e36b 60%, #b59f00 100%);
+    color: #232323;
+}
+
+tr.class-2.group-header td {
     background: linear-gradient(90deg, #174fa3 60%, #1f3262 100%);
     color: #fff;
 }
 
-tr.class-p2.group-header td {
+tr.class-3.group-header td {
+    background: linear-gradient(90deg, #d9534f 60%, #7a2624 100%);
+    color: #fff;
+}
+
+tr.class-4.group-header td {
     background: linear-gradient(90deg, #24c080 60%, #135c41 100%);
     color: #fff;
 }
 
-tr.class-gt3.group-header td {
-    background: linear-gradient(90deg, #f3c46a 60%, #917737 100%);
-    color: #232323;
+tr.class-5.group-header td {
+    background: linear-gradient(90deg, #d878d8 60%, #773977 100%);
+    color: #fff;
 }
 
 #standingsTable {

--- a/standings.js
+++ b/standings.js
@@ -32,7 +32,7 @@ async function fetchAndRenderStandings() {
             inPit: headers.indexOf("In Pit")
         };
 
-        // Map your internal class labels to display and sort order
+        // Map internal class labels to display name and order (1 = fastest)
         const CLASS_MAP = {
             "Hypercar":   { display: "Hypercar", order: 1 },
             "P2":         { display: "P2",       order: 2 },
@@ -79,21 +79,21 @@ const CLASS_ICON = {
     "GT3":      "🟩"
 };
 
-let lastClass = null;
+let lastClassOrder = null;
 for (const row of dataRows) {
     const tr = document.createElement('tr');
     const rawClass = row[colIdx.class];
-    let classKey = '';
+    let classOrder = 99;
     let classDisplay = rawClass;
     if (CLASS_MAP[rawClass]) {
-        classKey = CLASS_MAP[rawClass].display.toLowerCase();
+        classOrder = CLASS_MAP[rawClass].order;
         classDisplay = CLASS_MAP[rawClass].display;
     }
 
-    if (classKey !== lastClass) {
-        lastClass = classKey;
+    if (classOrder !== lastClassOrder) {
+        lastClassOrder = classOrder;
         const headerTr = document.createElement('tr');
-        headerTr.classList.add(`class-${classKey}`, 'group-header');
+        headerTr.classList.add(`class-${classOrder}`, 'group-header');
         const headerTd = document.createElement('td');
         headerTd.colSpan = headers.length;
         headerTd.textContent = classDisplay;
@@ -101,7 +101,7 @@ for (const row of dataRows) {
         tbody.appendChild(headerTr);
     }
 
-    tr.classList.add(`class-${classKey}`);
+    tr.classList.add(`class-${classOrder}`);
     if (row[colIdx.classPos] === "1") tr.classList.add('leader');
 
     [


### PR DESCRIPTION
## Summary
- generalize class color support up to five classes
- provide ordered palette in `race_data_runner.py`
- update CSS classes to `.class-1`–`.class-5`
- map table rendering in `standings.js` by class order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ff6b23f88832aae0242eb3201cff0