### PR TITLE
Improve filtering for non-driver entries

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -54,8 +54,10 @@ ANSI_COLOUR_MAP = {
 def filter_rows(rows):
     """Filter out non-racing entries from standings rows."""
     filtered = []
+    car_re = re.compile(r"car\s*\d+$", re.IGNORECASE)
     for r in rows:
-        driver = r.get("Driver", "")
+        driver = r.get("Driver", r.get("DriverName", ""))
+        team = r.get("Team", r.get("TeamName", ""))
         try:
             pos = int(r.get("Pos", 0))
         except Exception:
@@ -65,6 +67,12 @@ def filter_rows(rows):
         except Exception:
             laps = 0.0
         if driver in {"Pace Car", "Lily Bowling"}:
+            continue
+        if team == "Lily Bowling":
+            continue
+        d = driver.strip().lower()
+        t = team.strip().lower()
+        if d == t and car_re.match(d):
             continue
         if pos <= 0 or laps <= 0:
             continue

--- a/standings.js
+++ b/standings.js
@@ -31,6 +31,7 @@ async function fetchAndRenderStandings() {
 
         // Indexes for all columns we want, regardless of order
         const colIdx = {
+            team: headers.indexOf("Team"),
             driver: headers.indexOf("Driver"),
             class: headers.indexOf("Class"),
             pos: headers.indexOf("Pos"),
@@ -58,13 +59,17 @@ async function fetchAndRenderStandings() {
 
         // Gather all rows as arrays for easier sorting/filtering
         const rows = [];
+        const carRe = /^car\s*\d+$/i;
         for (let i = 1; i < lines.length; i++) {
             const row = lines[i].split(',').map(cell => cell.trim());
             if (row.length < headers.length) continue;
-            // Filter: skip if Driver is Lily Bowling or Pace Car
             const driverName = row[colIdx.driver];
+            const teamName = row[colIdx.team] || "";
             if (driverName === "Lily Bowling" || driverName === "Pace Car") continue;
-            // Hide entries with position 0 or non-positive lap count
+            if (teamName === "Lily Bowling") continue;
+            const d = driverName.toLowerCase();
+            const t = teamName.toLowerCase();
+            if (d === t && carRe.test(d)) continue;
             const pos = parseInt(row[colIdx.pos], 10);
             const laps = parseFloat(row[colIdx.laps]);
             if (pos === 0 || laps <= 0) continue;

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -39,12 +39,15 @@ def test_stop_logging_sends_sigint():
     assert gui.output_thread is None
 
 
-def test_filter_rows_removes_pace_and_zero_lap_entries():
+def test_filter_rows_removes_hidden_entries():
     rows = [
-        {"Driver": "DriverA", "Pos": "1", "Laps": "5"},
-        {"Driver": "Pace Car", "Pos": "1", "Laps": "5"},
-        {"Driver": "DriverB", "Pos": "0", "Laps": "2"},
-        {"Driver": "DriverC", "Pos": "3", "Laps": "0"},
+        {"Team": "T1", "Driver": "DriverA", "Pos": "1", "Laps": "5"},
+        {"Team": "Pace Car", "Driver": "Pace Car", "Pos": "1", "Laps": "5"},
+        {"Team": "TeamB", "Driver": "DriverB", "Pos": "0", "Laps": "2"},
+        {"Team": "TeamC", "Driver": "DriverC", "Pos": "3", "Laps": "0"},
+        {"Team": "Any", "Driver": "Lily Bowling", "Pos": "2", "Laps": "3"},
+        {"Team": "Lily Bowling", "Driver": "Someone", "Pos": "2", "Laps": "3"},
+        {"Team": "Car 20", "Driver": "Car 20", "Pos": "5", "Laps": "10"},
     ]
     filtered = filter_rows(rows)
     assert len(filtered) == 1


### PR DESCRIPTION
## Summary
- hide pace car, team 'Lily Bowling' and driverless cars in race GUI and standings overlay
- add tests covering new filtering rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffc5d16c8832ab518700fb3b8c5c0