### PR TITLE
Add EEC team dictionary

### DIFF
--- a/eec_teams.py
+++ b/eec_teams.py
@@ -1,0 +1,23 @@
+"""EEC team roster used for championship calculations."""
+
+TEAM_DRIVERS: dict[str, list[str]] = {
+    "Warriors of Light": [
+        "Alisaie Leveilleur",
+        "Alphinaud Leveilleur",
+    ],
+    "Scions of the Seventh Dawn": [
+        "Thancred Waters",
+        "Y'shtola Rhul",
+        "Urianger Augurelt",
+    ],
+    "Students of Baldesion": [
+        "Krile Baldesion",
+        "G'raha Tia",
+    ],
+    "Manderville Enterprises": [
+        "Hildibrand Manderville",
+        "Godbert Manderville",
+    ],
+}
+
+__all__ = ["TEAM_DRIVERS"]


### PR DESCRIPTION
## Summary
- add `eec_teams.py` containing a basic map of teams and their drivers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e858e204832a9859af691670fd85