### PR TITLE
Add base calendar structure

### DIFF
--- a/eec_calendar.py
+++ b/eec_calendar.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Optional, List, Dict
+
+
+@dataclass
+class Race:
+    """Represent a single race in the Eorzean Endurance Championship."""
+
+    round: int
+    name: str
+    date: date
+    track: str
+    logs: Optional[Path] = None
+
+    def available_logs(self) -> Dict[str, Path]:
+        """Return a mapping of log file names to paths if the log directory exists."""
+        if not self.logs or not self.logs.exists():
+            return {}
+        return {p.name: p for p in self.logs.iterdir() if p.is_file()}
+
+
+@dataclass
+class Season:
+    """Collection of races that make up a championship year."""
+
+    year: int
+    races: List[Race]
+
+
+# Example calendar.  Additional rounds can be appended in the future.
+EEC_2025 = Season(
+    year=2025,
+    races=[
+        Race(
+            round=1,
+            name="Round 1",
+            date=date(2025, 6, 4),
+            track="Unknown",
+            logs=Path("RaceLogs"),
+        ),
+    ],
+)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from datetime import date
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from eec_calendar import Race, Season
+
+
+def test_available_logs(tmp_path):
+    log_dir = tmp_path / "Race1"
+    log_dir.mkdir()
+    (log_dir / "foo.txt").write_text("data")
+    race = Race(round=1, name="R1", date=date.today(), track="N/A", logs=log_dir)
+    files = race.available_logs()
+    assert "foo.txt" in files
+    assert files["foo.txt"].is_file()
+
+
+def test_season_structure():
+    race = Race(round=1, name="R1", date=date.today(), track="N/A")
+    season = Season(year=2025, races=[race])
+    assert season.year == 2025
+    assert season.races[0] is race


### PR DESCRIPTION
## Summary
- add `eec_calendar.py` with Race and Season dataclasses
- implement helper to list available logs per race
- add tests for new calendar module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e87a6a40832abb399cc916df2369