### PR TITLE
Add options menu with log settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Logos and spec maps under `Logos/` and `SpecMaps/` contain the Final Fantasy XIV
 
 ## GUI
 A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  The window now includes tabs to view the `pitstop_log.csv`, `driver_swaps.csv` and `standings_log.csv` files directly, and a button to display `driver_times.csv` which lists the total drive time for each driver along with lap count, best lap time and average lap time.  The driver time view allows filtering by team and sorting by clicking the column headers.  If the optional `openai` package is installed and an `OPENAI_API_KEY` environment variable is set, the GUI can send the logs to ChatGPT and store the resulting analysis in a text file.
-The window also provides a simple *File* menu with a *Quit* action to close the application. A dark colour scheme based on the `clam` style is applied and the `Logos/App/EECApp.png` image will be used as the window icon when available.
+The window also provides a simple *File* menu with a *Quit* action to close the application. An *Options* menu lets you toggle automatic log scrolling and whether long lines wrap. A dark colour scheme based on the `clam` style is applied and the `Logos/App/EECApp.png` image will be used as the window icon when available.
 
 Run it with:
 

--- a/race_gui.py
+++ b/race_gui.py
@@ -100,6 +100,19 @@ class RaceLoggerGUI:
         file_menu = tk.Menu(menubar, tearoff=0)
         file_menu.add_command(label="Quit", command=self.on_close)
         menubar.add_cascade(label="File", menu=file_menu)
+        self.auto_scroll = tk.BooleanVar(value=True)
+        self.wrap_logs = tk.BooleanVar(value=True)
+        options_menu = tk.Menu(menubar, tearoff=0)
+        options_menu.add_checkbutton(
+            label="Auto Scroll Logs",
+            variable=self.auto_scroll,
+        )
+        options_menu.add_checkbutton(
+            label="Wrap Log Text",
+            variable=self.wrap_logs,
+            command=self.update_wrap,
+        )
+        menubar.add_cascade(label="Options", menu=options_menu)
         root.config(menu=menubar)
 
         self.notebook = ttk.Notebook(root)
@@ -145,6 +158,7 @@ class RaceLoggerGUI:
             insertbackground="white",
         )
         self.log_box.grid(column=0, row=7, columnspan=2, pady=5)
+        self.update_wrap()
 
         # Additional tabs for CSV logs
         self.create_csv_tab("pitstop_log.csv", "Pit Stops")
@@ -275,6 +289,10 @@ class RaceLoggerGUI:
             if os.path.exists(f):
                 shutil.copy(f, target)
         messagebox.showinfo("Saved", f"Logs copied to {target}")
+
+    def update_wrap(self) -> None:
+        wrap = tk.WORD if self.wrap_logs.get() else tk.NONE
+        self.log_box.configure(wrap=wrap)
 
     def create_csv_tab(self, csv_path: str, title: str) -> None:
         frame = ttk.Frame(self.notebook, padding=10)
@@ -613,7 +631,8 @@ class RaceLoggerGUI:
                 line = self.log_queue.get_nowait()
                 self.log_box.configure(state="normal")
                 self.insert_with_ansi(line)
-                self.log_box.see("end")
+                if self.auto_scroll.get():
+                    self.log_box.see("end")
                 self.log_box.configure(state="disabled")
         except Empty:
             pass


### PR DESCRIPTION
## Summary
- add Options menu to the GUI
- allow toggling auto scroll and log wrapping
- document Options menu in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e9e96148832a9d7b1d2ca60308c7