### PR TITLE
Convert stint tracker to popout overlay

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -264,3 +264,86 @@ def test_view_series_standings_uses_toplevel(monkeypatch, tmp_path):
 
     assert calls.get("title") == "Series Standings"
 
+
+def test_view_stint_tracker_uses_toplevel(monkeypatch):
+    calls = {}
+
+    class DummyTop:
+        def __init__(self, root):
+            calls["root"] = root
+
+        def title(self, t):
+            calls["title"] = t
+
+        def protocol(self, *a, **k):
+            pass
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def rowconfigure(self, *a, **k):
+            pass
+
+        def columnconfigure(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+        def heading(self, *a, **k):
+            pass
+
+        def column(self, *a, **k):
+            return {"width": 100}
+
+        def bind(self, *a, **k):
+            pass
+
+        def yview(self, *a, **k):
+            pass
+
+        def set(self, *a, **k):
+            pass
+
+    class DummyTree(DummyWidget):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.opts = {}
+
+        def delete(self, *a, **k):
+            pass
+
+        def get_children(self, *a, **k):
+            return []
+
+        def __setitem__(self, k, v):
+            self.opts[k] = v
+
+        def __getitem__(self, k):
+            return self.opts.get(k)
+
+        def insert(self, *a, **k):
+            pass
+
+    monkeypatch.setattr("race_gui.tk.Toplevel", DummyTop)
+    monkeypatch.setattr("race_gui.ttk.Frame", DummyWidget)
+    monkeypatch.setattr("race_gui.ttk.Treeview", DummyTree)
+    monkeypatch.setattr("race_gui.ttk.Scrollbar", DummyWidget)
+    monkeypatch.setattr("race_gui.ttk.Button", DummyWidget)
+    monkeypatch.setattr(
+        "race_gui.messagebox",
+        types.SimpleNamespace(showinfo=lambda *a, **k: None, showerror=lambda *a, **k: None),
+    )
+
+    gui = types.SimpleNamespace(root=object(), update_stint_table=lambda: None)
+    RaceLoggerGUI.view_stint_tracker(gui)
+
+    assert calls.get("title") == "Stint Tracker"
+


### PR DESCRIPTION
## Summary
- add a button to open a new "Stint Tracker" overlay
- implement the `view_stint_tracker` popout window
- start the stint tracker update loop from the logger tab
- test coverage for the new window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684285c71eb8832a92366d6752ac7101