### PR TITLE
Fix live feed pitstop detection

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -1396,7 +1396,10 @@ class RaceLoggerGUI:
         l = line.lower()
         if "overtook" in l:
             self.add_event("overtake", line.strip())
-        if "pitted" in l:
+        if "pitted" in l or "pit -" in l or "pit \u2013" in l:
+            # Tail logs emit lines like "PIT – Team / Driver" using an en dash.
+            # Include both the plain hyphen and en dash variants so the feed
+            # catches them regardless of terminal font or encoding.
             self.add_event("pitstop", line.strip())
         if "driver swap" in l or "swapped" in l:
             self.add_event("driver_swap", line.strip())


### PR DESCRIPTION
## Summary
- handle "PIT –" lines in `parse_event` to recognise pit stops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428698cc90832aac1f9e29bcdaed47