### PR TITLE
Add manual refresh for Stint Tracker

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -685,6 +685,10 @@ class RaceLoggerGUI:
         self.stint_sort_reverse = False
         self.update_stint_table()
 
+        ttk.Button(frame, text="Refresh", command=self.update_stint_table).grid(
+            row=1, column=0, columnspan=2, pady=5
+        )
+
         def on_close() -> None:
             self.stint_tree = None
             self.stint_win = None


### PR DESCRIPTION
## Summary
- allow Stint Tracker window to manually refresh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428999143c832ab6ab6d452d9c0ad2