### PR TITLE
Show placeholder when standings unavailable

### DIFF
--- a/standings.css
+++ b/standings.css
@@ -138,3 +138,9 @@ tr.class-5.group-header td {
     font-size: 1.23em;
     vertical-align: middle;
 }
+
+tr.placeholder td {
+    text-align: center;
+    padding: 1em;
+    font-style: italic;
+}

--- a/standings.js
+++ b/standings.js
@@ -19,13 +19,22 @@ function formatNumber(value) {
     return str;
 }
 
+function showPlaceholder(message) {
+    const tbody = document.querySelector('#standingsTable tbody');
+    tbody.innerHTML = `<tr class="placeholder"><td colspan="${TABLE_COLS.length}">${message}</td></tr>`;
+}
+
 async function fetchAndRenderStandings() {
     try {
         const response = await fetch('sorted_standings.csv?_=' + new Date().getTime());
         const csv = await response.text();
 
         const lines = csv.trim().split('\n');
-        if (lines.length < 2) return; // No data
+        if (lines.length < 2) {
+            standingsData = [];
+            showPlaceholder('No standings yet – waiting for logger');
+            return;
+        }
 
         const headers = lines[0].split(',').map(h => h.trim());
 
@@ -77,11 +86,16 @@ async function fetchAndRenderStandings() {
             rows.push(row);
         }
         standingsData = rows;
+        if (rows.length === 0) {
+            showPlaceholder('No valid data yet – session may not have started');
+            return;
+        }
         renderStandings();
 
     } catch (e) {
         // Optionally show error in overlay or log to console
         // console.error(e);
+        showPlaceholder('Error loading standings');
     }
 }
 


### PR DESCRIPTION
## Summary
- show user-friendly message when CSV hasn't been created yet
- show message when no valid data rows were found
- display error notice if standings can't load
- style placeholder row in overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842995d89fc832a9de9ca23a06d2380