### PR TITLE
Fix standings log tab refresh

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -207,7 +207,11 @@ class RaceLoggerGUI:
 
         # Additional tabs for CSV logs
         self.create_csv_tab("driver_swaps.csv", "Driver Swaps")
-        self.create_standings_log_tab("standings_log.csv", "Standings Log")
+        # Auto-refresh the standings log viewer so it stays in sync with the
+        # running logger.
+        self.create_standings_log_tab(
+            "standings_log.csv", "Standings Log", auto_refresh=True
+        )
         self.create_team_editor_tab()
 
         # Start stint tracker update loop


### PR DESCRIPTION
## Summary
- auto-refresh the Standings Log viewer in the race GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429ace55cc832aad41d3a256fb3ca0