### PR TITLE
Add SQLite-based data storage

### DIFF
--- a/eec_db.py
+++ b/eec_db.py
@@ -1,0 +1,86 @@
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Any
+
+__all__ = ["init_db", "insert", "connect"]
+
+
+def connect(path: str | Path) -> sqlite3.Connection:
+    """Return a connection to the SQLite database."""
+    return sqlite3.connect(str(path))
+
+
+def init_db(path: str | Path) -> sqlite3.Connection:
+    """Initialise the SQLite database and return the connection."""
+    conn = connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS standings (
+            time TEXT,
+            car_idx INTEGER,
+            team TEXT,
+            driver TEXT,
+            class_id TEXT,
+            position INTEGER,
+            class_position INTEGER,
+            lap INTEGER,
+            best_lap REAL,
+            last_lap REAL,
+            on_pit INTEGER,
+            pit_count INTEGER
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS pitstops (
+            car_idx INTEGER,
+            class TEXT,
+            team TEXT,
+            driver TEXT,
+            start_ts TEXT,
+            end_ts TEXT,
+            start_sess REAL,
+            end_sess REAL,
+            start_lap INTEGER,
+            end_lap INTEGER,
+            duration_sec REAL,
+            duration TEXT,
+            duration_laps INTEGER
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS driver_swaps (
+            timestamp TEXT,
+            car_idx INTEGER,
+            team TEXT,
+            driver_out TEXT,
+            driver_in TEXT,
+            lap INTEGER
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS driver_totals (
+            team TEXT,
+            driver TEXT,
+            total_time REAL,
+            total_laps INTEGER,
+            best_lap REAL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def insert(conn: sqlite3.Connection, table: str, row: Iterable[Any]) -> None:
+    """Insert a row tuple into the given table."""
+    placeholders = ",".join(["?"] * len(row))
+    conn.execute(f"INSERT INTO {table} VALUES ({placeholders})", tuple(row))
+    conn.commit()
+

--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -1,4 +1,5 @@
 # race_data_runner.py
+import argparse
 import subprocess, signal, sys, time, os, threading, shutil
 import csv, itertools
 from pathlib import Path
@@ -7,6 +8,17 @@ from datetime import datetime
 # Ensure all relative paths resolve to the directory this file lives in
 BASE_DIR = Path(__file__).resolve().parent
 os.chdir(BASE_DIR)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Race data runner")
+    parser.add_argument("--db", default="eec_log.db", help="SQLite database file")
+    args, _ = parser.parse_known_args()
+    return args
+
+
+ARGS = parse_args()
+DB_PATH = Path(ARGS.db)
 try:
     from colorama import init as _init, Fore, Style
     try:
@@ -57,8 +69,14 @@ def colour_for(cls: str) -> str:
 
 
 SCRIPTS = [
-    ("AI Logger",        ["python", str(BASE_DIR / "ai_standings_logger.py")]),
-    ("Pit Logger",       ["python", str(BASE_DIR / "pitstop_logger_enhanced.py")]),
+    (
+        "AI Logger",
+        ["python", str(BASE_DIR / "ai_standings_logger.py"), "--db", str(DB_PATH)],
+    ),
+    (
+        "Pit Logger",
+        ["python", str(BASE_DIR / "pitstop_logger_enhanced.py"), "--db", str(DB_PATH)],
+    ),
     ("Standings Sorter", ["python", str(BASE_DIR / "standings_sorter.py")]),
     # add more here as needed
 ]

--- a/race_gui.py
+++ b/race_gui.py
@@ -129,6 +129,7 @@ class RaceLoggerGUI:
         self.output_thread = None
         self.teams_file = Path(eec_teams.__file__).resolve()
         self.team_drivers = self.load_team_drivers()
+        self.db_path = Path("eec_log.db")
 
         menubar = tk.Menu(root)
         file_menu = tk.Menu(menubar, tearoff=0)
@@ -331,7 +332,7 @@ class RaceLoggerGUI:
         if not runner.exists():
             runner = Path(sys.argv[0]).resolve().parent.parent / "race_data_runner.py"
         self.proc = subprocess.Popen(
-            ["python", str(runner)],
+            ["python", str(runner), "--db", str(self.db_path)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -1,5 +1,6 @@
 import runpy
 import sys
+import sqlite3
 import types
 import csv
 import time
@@ -46,6 +47,8 @@ def test_ai_standings_logger_writes_csv(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(sys, "argv", ["ai_standings_logger.py", "--db", str(db_path)])
     module = runpy.run_module("ai_standings_logger", run_name="__main__")
 
     csv_path = tmp_path / "standings_log.csv"
@@ -54,6 +57,10 @@ def test_ai_standings_logger_writes_csv(tmp_path, monkeypatch):
     assert len(rows) == 2
     assert rows[1][2] == "TeamA"
     assert rows[1][3] == "DriverA"
+    conn = sqlite3.connect(db_path)
+    db_rows = list(conn.execute("SELECT * FROM standings"))
+    conn.close()
+    assert len(db_rows) == 1
 
 
 def test_pitstop_logger_writes_stint(tmp_path, monkeypatch):
@@ -99,6 +106,8 @@ def test_pitstop_logger_writes_stint(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    db_path = tmp_path / "test2.db"
+    monkeypatch.setattr(sys, "argv", ["pitstop_logger_enhanced.py", "--db", str(db_path)])
     module = runpy.run_module("pitstop_logger_enhanced", run_name="__main__")
 
     csv_path = tmp_path / "pitstop_log.csv"
@@ -107,3 +116,7 @@ def test_pitstop_logger_writes_stint(tmp_path, monkeypatch):
     assert len(rows) == 2
     # ensure the stint duration laps column is present
     assert rows[1][-1] == "1"
+    conn = sqlite3.connect(db_path)
+    db_rows = list(conn.execute("SELECT * FROM pitstops"))
+    conn.close()
+    assert len(db_rows) == 1


### PR DESCRIPTION
## Summary
- add `eec_db.py` for common DB helpers
- update loggers to optionally log to SQLite
- propagate `--db` option through race runner and GUI
- extend logger tests for database validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684299c7eca8832a8a57e8abba39f6d1