### PR TITLE
Add watchfiles detection and auto-install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pyirsdk
 openai  # optional for ChatGPT export via race_gui.py
 sv_ttk   # modern theme for the Tkinter GUI
 
-watchfiles
+watchfiles>=0.21.0

--- a/tests/test_runner_watchfiles.py
+++ b/tests/test_runner_watchfiles.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from race_data_runner import ensure_watchfiles
+
+
+def test_ensure_watchfiles_installed(tmp_path, monkeypatch):
+    pkg = tmp_path / "watchfiles"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("def watch(*a, **k):\n    return []\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    watch = ensure_watchfiles()
+    assert callable(watch)
+
+
+def test_runner_missing_watchfiles(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path)
+    proc = subprocess.run([sys.executable, "-S", "race_data_runner.py"], capture_output=True, text=True, env=env)
+    assert proc.returncode == 1
+    assert "watchfiles' package is not installed" in proc.stdout


### PR DESCRIPTION
## Summary
- gracefully handle missing `watchfiles` in race_data_runner
- support optional `--auto-install` flag
- add tests for installed and missing watchfiles situations
- bump requirement to `watchfiles>=0.21.0`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429fe43fd0832a95b5b2ec74e148d0