### PR TITLE
Improve watchfiles handling

### DIFF
--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -38,8 +38,9 @@ watch: Any
 def ensure_watchfiles(auto_install: bool = False) -> Any:
     """Return the :func:`watch` function from the watchfiles package.
 
-    Attempts installation when ``auto_install`` is ``True`` and the module is
-    missing.
+    Attempts installation when ``auto_install`` is ``True`` or the
+    ``EEC_AUTO_INSTALL`` environment variable is set to ``"1"`` and the module
+    is missing.
 
     >>> import types, sys
     >>> mod = types.SimpleNamespace(watch=lambda: None)
@@ -52,6 +53,8 @@ def ensure_watchfiles(auto_install: bool = False) -> Any:
     ... except SystemExit as exc:
     ...     assert exc.code == 1
     """
+    env_auto = os.getenv("EEC_AUTO_INSTALL", "1") == "1"
+    auto_install = auto_install or env_auto
     try:
         from watchfiles import watch as watch_func
         return watch_func
@@ -71,7 +74,7 @@ def ensure_watchfiles(auto_install: bool = False) -> Any:
             sys.exit(1)
         print(
             "Error: The 'watchfiles' package is not installed.\n"
-            "Run python -m pip install watchfiles and try again."
+            "Run python -m pip install watchfiles or start with --auto-install."
         )
         sys.exit(1)
 

--- a/tests/test_runner_watchfiles.py
+++ b/tests/test_runner_watchfiles.py
@@ -19,6 +19,7 @@ def test_ensure_watchfiles_installed(tmp_path, monkeypatch):
 def test_runner_missing_watchfiles(tmp_path):
     env = os.environ.copy()
     env["PYTHONPATH"] = str(tmp_path)
+    env["EEC_AUTO_INSTALL"] = "0"
     proc = subprocess.run([sys.executable, "-S", "race_data_runner.py"], capture_output=True, text=True, env=env)
     assert proc.returncode == 1
     assert "watchfiles' package is not installed" in proc.stdout


### PR DESCRIPTION
## Summary
- auto-install `watchfiles` unless `EEC_AUTO_INSTALL=0`
- clarify hint in error message
- adjust tests for new environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a61f7c84832ab88cf15cf34d869e