### PR TITLE
Cleanup and portability improvements

### DIFF
--- a/codebase_cleaner.py
+++ b/codebase_cleaner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
-import os
 import subprocess
 import sys
 import time

--- a/pitstop_logger_enhanced.py
+++ b/pitstop_logger_enhanced.py
@@ -1,6 +1,5 @@
 import argparse
 import irsdk, csv, time
-from typing import Optional
 
 import eec_db
 try:

--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -6,9 +6,7 @@ import sys
 import time
 import os
 import threading
-import shutil
 import csv
-import itertools
 from pathlib import Path
 from datetime import datetime
 from typing import Any
@@ -129,13 +127,13 @@ def build_scripts(db_path: Path) -> list[tuple[str, list[str]]]:
     return [
         (
             "AI Logger",
-            ["python", str(BASE_DIR / "ai_standings_logger.py"), "--db", str(db_path)],
+            [sys.executable, str(BASE_DIR / "ai_standings_logger.py"), "--db", str(db_path)],
         ),
         (
             "Pit Logger",
-            ["python", str(BASE_DIR / "pitstop_logger_enhanced.py"), "--db", str(db_path)],
+            [sys.executable, str(BASE_DIR / "pitstop_logger_enhanced.py"), "--db", str(db_path)],
         ),
-        ("Standings Sorter", ["python", str(BASE_DIR / "standings_sorter.py")]),
+        ("Standings Sorter", [sys.executable, str(BASE_DIR / "standings_sorter.py")]),
         # add more here as needed
     ]
 

--- a/race_gui.py
+++ b/race_gui.py
@@ -419,7 +419,7 @@ class RaceLoggerGUI:
         if not runner.exists():
             runner = Path(sys.argv[0]).resolve().parent.parent / "race_data_runner.py"
         self.proc = subprocess.Popen(
-            ["python", str(runner), "--db", str(self.db_path)],
+            [sys.executable, str(runner), "--db", str(self.db_path)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -1701,19 +1701,6 @@ def check_dependencies(logger: logging.Logger) -> None:
         logger.warning("module 'sv_ttk' not installed – falling back to default theme")
     if irsdk is None:
         logger.warning("module 'irsdk' not installed")
-
-
-def open_log_file(path: Path) -> None:
-    """Open the given log file with the default application."""
-    try:
-        if sys.platform == "win32":
-            os.startfile(path)  # type: ignore[attr-defined]
-        elif sys.platform == "darwin":
-            subprocess.run(["open", str(path)], check=False)
-        else:
-            subprocess.run(["xdg-open", str(path)], check=False)
-    except Exception:
-        pass
 
 
 def start_heartbeat(start_event: threading.Event) -> None:

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -47,7 +47,6 @@ def test_main_failure(monkeypatch, tmp_path, capsys):
 
     monkeypatch.setattr(race_gui.tk, '_default_root', None)
     monkeypatch.setattr(race_gui.tk, 'Tk', boom)
-    monkeypatch.setattr(race_gui, 'open_log_file', lambda *_: None)
 
     with pytest.raises(RuntimeError):
         race_gui.main([])


### PR DESCRIPTION
## Summary
- drop unused imports and dead helper
- use `sys.executable` when spawning child processes
- adjust GUI tests to match updated API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843fb6c8d84832a8b23d5c11adfb75d