### PR TITLE
Add pytest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,24 @@ dependencies from `requirements.txt`:
 ./setup.sh
 ```
 
+
 The optional `openai` package can be installed afterwards if you plan to
 use the ChatGPT export feature in the GUI.
+
+## Testing
+
+Install the dependencies and `pytest` first:
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+```
+
+Then run the test suite from the project root:
+
+```bash
+pytest
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add a Testing section to the README with pytest instructions

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fdd67f48832aa65b0928e1658a89