### PR TITLE
Add console entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,21 @@ dependencies from `requirements.txt`:
 The optional `openai` package can be installed afterwards if you plan to
 use the ChatGPT export feature in the GUI.
 
+After activating the environment install the project in editable mode so the
+command line entry points are available:
+
+```bash
+pip install -e .
+```
+
+This provides the `race-data-runner` and `race-gui` commands used below.
+
 ## Usage
 
 Run the race data runner which spawns the loggers and sorter:
 
 ```bash
-python race_data_runner.py
+race-data-runner
 ```
 
 This creates CSV log files in the repository directory and writes console output to the `logs/` folder. The `standings.html` file reads `sorted_standings.csv` and together with `standings.js` and `standings.css` provides a live overlay you can open in a browser or streaming tool.
@@ -51,7 +60,7 @@ The window also provides a simple *File* menu with a *Quit* action to close the 
 Run it with:
 
 ```bash
-python race_gui.py
+race-gui
 ```
 
 ### Building an executable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eec"
+version = "0.1.0"
+description = "Utilities for logging and displaying data from iRacing AI races"
+requires-python = ">=3.9"
+dependencies = [
+    "pandas",
+    "colorama",
+    "pyirsdk",
+    "sv_ttk",
+    "watchfiles>=0.21.0",
+]
+
+[project.scripts]
+race-gui = "race_gui:main"
+race-data-runner = "race_data_runner:main"
+
+[tool.setuptools]
+py-modules = [
+    "ai_standings_logger",
+    "codebase_cleaner",
+    "eec_calendar",
+    "eec_db",
+    "eec_teams",
+    "ensure_dependencies",
+    "pitstop_logger_enhanced",
+    "race_data_runner",
+    "race_gui",
+    "roster_ui",
+    "standings_sorter",
+    "teams_tab",
+]


### PR DESCRIPTION
## Summary
- define project metadata and console scripts in `pyproject.toml`
- document editable install and new commands in README

## Testing
- `pip install -e .`
- `race-data-runner --help`
- `race-gui --help`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fdde8828832a94117872b65d2176