### PR TITLE
Fix GUI runner launch in frozen builds

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -180,6 +180,16 @@ def estimate_remaining_pits(
     return max(0, int(secs_left / expected))
 
 
+def _find_python() -> str:
+    """Return the preferred Python executable for launching child scripts."""
+    exe = sys.executable
+    if getattr(sys, "frozen", False):
+        candidate = Path(exe).with_name("python.exe" if os.name == "nt" else "python")
+        if candidate.exists():
+            return str(candidate)
+    return exe
+
+
 class RaceLoggerGUI:
     def __init__(self, root: tk.Tk, *, classic_theme: bool = False):
         self.root = root
@@ -418,8 +428,12 @@ class RaceLoggerGUI:
         runner = Path(sys.argv[0]).resolve().parent / "race_data_runner.py"
         if not runner.exists():
             runner = Path(sys.argv[0]).resolve().parent.parent / "race_data_runner.py"
+
+        python = _find_python()
+        cmd = [python, str(runner), "--db", str(self.db_path)]
+        print(f"[INFO] Launching {runner.name} --db {self.db_path}")
         self.proc = subprocess.Popen(
-            [sys.executable, str(runner), "--db", str(self.db_path)],
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/race_gui.spec
+++ b/race_gui.spec
@@ -1,10 +1,17 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
+import os
+import sys
+
+
+PYTHON_EXE = sys._base_executable
+PYTHON_NAME = 'python.exe' if os.name == 'nt' else 'python'
+
 a = Analysis(
     ['race_gui.py'],
     pathex=[],
-    binaries=[],
+    binaries=[(PYTHON_EXE, PYTHON_NAME)],
     datas=[],
     hiddenimports=[],
     hookspath=[],

--- a/tests/test_gui_cli_mode.py
+++ b/tests/test_gui_cli_mode.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'race_gui.py'
+
+def test_cli_debug(monkeypatch):
+    env = os.environ.copy()
+    env['EEC_DUMMY_TK'] = '1'
+    proc = subprocess.run([sys.executable, str(SCRIPT), '--debug'], capture_output=True, text=True, env=env)
+    assert proc.returncode == 0
+    assert 'Race GUI started successfully' in proc.stdout

--- a/tests/test_gui_start_logging.py
+++ b/tests/test_gui_start_logging.py
@@ -1,0 +1,45 @@
+import sys
+import types
+from pathlib import Path
+import race_gui
+
+class DummyButton:
+    def config(self, **kwargs):
+        pass
+
+
+def test_start_logging_builds_command(monkeypatch, tmp_path, capsys):
+    gui = types.SimpleNamespace(
+        proc=None,
+        db_path=tmp_path / "eec_log.db",
+        start_btn=DummyButton(),
+        stop_btn=DummyButton(),
+        read_output=lambda: None,
+    )
+
+    called = {}
+
+    def fake_thread(*a, **k):
+        called['thread'] = True
+        class T:
+            def start(self):
+                called['thread_started'] = True
+        return T()
+
+    def fake_popen(args, **kwargs):
+        called['args'] = args
+        class P:
+            stdout=None
+        return P()
+
+    monkeypatch.setattr(race_gui.threading, 'Thread', fake_thread)
+    monkeypatch.setattr(race_gui.subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(race_gui, '_find_python', lambda: '/usr/bin/python')
+    monkeypatch.setattr(race_gui, 'messagebox', types.SimpleNamespace(showinfo=lambda *a, **k: None))
+
+    race_gui.RaceLoggerGUI.start_logging(gui)
+    out = capsys.readouterr().out
+    assert called['args'][0] == '/usr/bin/python'
+    assert Path(called['args'][1]).name == 'race_data_runner.py'
+    assert '--db' in called['args']
+    assert 'Launching race_data_runner.py --db' in out


### PR DESCRIPTION
## Summary
- ensure packaged GUI locates an embedded Python interpreter
- spawn the runner using that interpreter
- show a startup message when the runner launches
- bundle a Python executable via the PyInstaller spec
- test subprocess argument construction and CLI mode

## Testing
- `pytest -q tests/test_gui_start_logging.py tests/test_gui_cli_mode.py tests/test_gui_main.py::test_main_success`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440b43ef98832a800883656d1410dc