### PR TITLE
Fix GUI startup size

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -203,6 +203,8 @@ class RaceLoggerGUI:
     def __init__(self, root: tk.Tk, *, classic_theme: bool = False):
         self.root = root
         self.root.title("EEC Logger")
+        # Ensure the window is large enough when it first appears
+        self.root.minsize(800, 600)
 
         self.theme = self.setup_style(classic_theme)
         icon_path = Path(__file__).resolve().parent / "Logos" / "App" / "EECApp.png"


### PR DESCRIPTION
## Summary
- set a minimum window size in `race_gui.py` so the GUI never launches as a tiny white window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684454fc2084832ab2f9250fa337f32d