### PR TITLE
Fix missing modern theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Logos and spec maps under `Logos/` and `SpecMaps/` contain the Final Fantasy XIV
 
 ## GUI
 A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  Tabs are available to view the `driver_swaps.csv` and `standings_log.csv` files directly, while buttons open the `pitstop_log.csv`, `driver_times.csv` and `series_standings.csv` logs in their own windows.  The driver time view allows filtering by team and sorting by clicking the column headers.  If the optional `openai` package is installed and an `OPENAI_API_KEY` environment variable is set, the GUI can send the logs to ChatGPT and store the resulting analysis in a text file.  A **Live Race Feed** tab displays the latest overtakes, pit stops, driver swaps, fastest laps and penalties and refreshes automatically. A **View Live Feed…** button opens a new window showing the latest overtakes, pit stops, driver swaps, fastest laps and penalties which refreshes automatically.
-The window also provides a simple *File* menu with a *Quit* action to close the application. A modern dark theme from the `sv_ttk` package is applied and the `Logos/App/EECApp.png` image will be used as the window icon when available.
+The window also provides a simple *File* menu with a *Quit* action to close the application. A modern dark theme from the `sv_ttk` package is applied and the `Logos/App/EECApp.png` image will be used as the window icon when available. Ensure `sv_ttk` is installed for the modern look – the GUI attempts to install it automatically when missing.
 
 Run it with:
 

--- a/race_gui.py
+++ b/race_gui.py
@@ -23,6 +23,12 @@ import platform
 import traceback
 
 import eec_teams
+import importlib
+
+try:
+    from ensure_dependencies import ensure_package
+except Exception:
+    ensure_package = None
 
 try:
     import irsdk
@@ -1738,10 +1744,18 @@ def check_environment(logger: logging.Logger) -> None:
 
 
 def check_dependencies(logger: logging.Logger) -> None:
-    """Warn about missing optional dependencies."""
+    """Ensure optional dependencies are available and log warnings."""
     if OPENAI_IMPORT_ERROR is not None:
         logger.warning("module 'openai' not installed – OpenAI features disabled")
-    if SVTTK_IMPORT_ERROR is not None:
+    if SVTTK_IMPORT_ERROR is not None and ensure_package is not None:
+        logger.warning("module 'sv_ttk' not installed – attempting automatic installation")
+        try:
+            ensure_package("sv_ttk")
+            globals()["sv_ttk"] = importlib.import_module("sv_ttk")
+            logger.info("Installed 'sv_ttk' for modern theme")
+        except Exception as exc:
+            logger.error("Failed to install 'sv_ttk': %s", exc)
+    elif SVTTK_IMPORT_ERROR is not None:
         logger.warning("module 'sv_ttk' not installed – falling back to default theme")
     if irsdk is None:
         logger.warning("module 'irsdk' not installed")

--- a/tests/test_gui_dependencies.py
+++ b/tests/test_gui_dependencies.py
@@ -1,0 +1,27 @@
+import types
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import race_gui
+
+
+def test_check_dependencies_installs_sv_ttk(monkeypatch):
+    installed = {}
+
+    def fake_ensure(pkg):
+        installed['pkg'] = pkg
+
+    monkeypatch.setattr(race_gui, 'SVTTK_IMPORT_ERROR', ImportError())
+    monkeypatch.setattr(race_gui, 'sv_ttk', None)
+    monkeypatch.setattr(race_gui, 'ensure_package', fake_ensure)
+    monkeypatch.setattr(
+        race_gui,
+        'importlib',
+        types.SimpleNamespace(import_module=lambda n: 'dummy')
+    )
+
+    logger = race_gui.logging.getLogger('test')
+    race_gui.check_dependencies(logger)
+    assert installed.get('pkg') == 'sv_ttk'
+    assert race_gui.sv_ttk == 'dummy'


### PR DESCRIPTION
## Summary
- ensure `sv_ttk` is available when starting the GUI
- document automatic installation of the theme
- test that missing theme triggers install

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445569c20c832aa1046d2707e527c3