### PR TITLE
Fix BASE_DIR detection for PyInstaller

### DIFF
--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -11,8 +11,12 @@ from pathlib import Path
 from datetime import datetime
 from typing import Any
 
-# Ensure all relative paths resolve to the directory this file lives in
-BASE_DIR = Path(__file__).resolve().parent
+# Ensure all relative paths resolve to the project directory
+if getattr(sys, "frozen", False):
+    # Running inside a PyInstaller bundle
+    BASE_DIR = Path(sys._MEIPASS)
+else:
+    BASE_DIR = Path(__file__).resolve().parent
 os.chdir(BASE_DIR)
 
 


### PR DESCRIPTION
## Summary
- support PyInstaller onefile mode in `race_data_runner.py`

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684459e8cce0832a8ecb5a43db113125