### PR TITLE
Fix sv_ttk fallback and bundle resources

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -211,6 +211,8 @@ class RaceLoggerGUI:
         self.root.title("EEC Logger")
         # Ensure the window is large enough when it first appears
         self.root.minsize(800, 600)
+        if hasattr(self.root, "geometry"):
+            self.root.geometry("1100x800")
 
         self.theme = self.setup_style(classic_theme)
         icon_path = Path(__file__).resolve().parent / "Logos" / "App" / "EECApp.png"
@@ -410,15 +412,21 @@ class RaceLoggerGUI:
         if not classic and sv_ttk is not None:
             try:
                 sv_ttk.set_theme("dark", self.root)
+                if hasattr(style, "layout") and not style.layout("TButton"):
+                    raise RuntimeError("sv_ttk theme resources missing")
                 theme = style.theme_use()
             except Exception:
-                pass
+                try:
+                    style.theme_use("clam")
+                except Exception:
+                    pass
+                theme = "clam"
         else:
             try:
                 style.theme_use("clam")
             except Exception:
                 pass
-            theme = style.theme_use()
+            theme = "clam"
         self.bg = "#23272e"
         self.fg = "#e7e7ff"
         accent = "#3c445c"

--- a/race_gui.spec
+++ b/race_gui.spec
@@ -3,6 +3,7 @@
 
 import os
 import sys
+from PyInstaller.utils.hooks import collect_data_files
 
 
 PYTHON_EXE = sys._base_executable
@@ -12,7 +13,7 @@ a = Analysis(
     ['race_gui.py'],
     pathex=[],
     binaries=[(PYTHON_EXE, PYTHON_NAME)],
-    datas=[],
+    datas=collect_data_files("sv_ttk"),
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary
- enlarge GUI window by default
- fall back to clam theme when sv_ttk is missing
- include sv_ttk data files when building with PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844597f54e0832a8b26b8ea64ac76d5