### PR TITLE
Add configurable race time left for pit estimates

### DIFF
--- a/tests/test_parse_cli.py
+++ b/tests/test_parse_cli.py
@@ -16,12 +16,12 @@ def _ns(**kwargs) -> argparse.Namespace:
 
 
 def test_parse_cli_defaults():
-    assert parse_cli([]) == _ns(debug=False, debug_shell=False, classic_theme=False, no_openai=False, db="eec_log.db")
+    assert parse_cli([]) == _ns(debug=False, debug_shell=False, classic_theme=False, no_openai=False, db="eec_log.db", time_left=None)
 
 
 def test_parse_cli_all_flags():
-    args = ["--debug", "--debug-shell", "--classic-theme", "--no-openai", "--db", "foo.db"]
-    assert parse_cli(args) == _ns(debug=True, debug_shell=True, classic_theme=True, no_openai=True, db="foo.db")
+    args = ["--debug", "--debug-shell", "--classic-theme", "--no-openai", "--db", "foo.db", "--time-left", "1:00:00"]
+    assert parse_cli(args) == _ns(debug=True, debug_shell=True, classic_theme=True, no_openai=True, db="foo.db", time_left=3600)
 
 
 def test_parse_cli_bug_repro():
@@ -30,4 +30,4 @@ def test_parse_cli_bug_repro():
 
 def test_parse_cli_mixed_unknown():
     ns = parse_cli(["--debug", "--foo", "extra.txt", "--db", "bar.db"])
-    assert ns == _ns(debug=True, debug_shell=False, classic_theme=False, no_openai=False, db="bar.db")
+    assert ns == _ns(debug=True, debug_shell=False, classic_theme=False, no_openai=False, db="bar.db", time_left=None)


### PR DESCRIPTION
## Summary
- allow parsing of race time format like `H:M:S`
- add `--time-left` CLI flag and pass value into `RaceLoggerGUI`
- let GUI users set remaining race time via an option
- use custom race end when estimating remaining pits
- update CLI parsing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445946f2b4832aaa28c8258505bcca