### PR TITLE
Detect session changes and rotate logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ A collection of utilities for logging and displaying data from iRacing AI races.
 
 - **ai_standings_logger.py** – periodically records session standings to
   a CSV file (default `standings_log.csv`).  Use `--output` and `--interval`
-  arguments to configure the file path and polling delay.
-- **pitstop_logger_enhanced.py** – tracks stints and pit stops, writing results to `pitstop_log.csv` and updating `live_standings_overlay.html`.
+  arguments to configure the file path and polling delay.  When the iRacing
+  session number changes the current log file is archived under
+  `RaceLogs/` and a new one is created automatically.
+- **pitstop_logger_enhanced.py** – tracks stints and pit stops, writing results to `pitstop_log.csv` and updating `live_standings_overlay.html`. When a new session starts existing logs are archived to `RaceLogs/` and fresh ones are created.
 - **standings_sorter.py** – produces `sorted_standings.csv` so the overlay can show the latest order per class.
 - **race_data_runner.py** – helper script that launches all of the above and restarts them if they stop.
 - **roster_ui.py** – displays team rosters in a scrollable window. Use `--refresh-ms` to set the auto-refresh interval.

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -26,6 +26,8 @@ def test_ai_standings_logger_writes_csv(tmp_path, monkeypatch):
                         }
                     ]
                 }
+            if key == "SessionNum":
+                return 0
             data = {
                 "CarIdxLap": [1],
                 "CarIdxPosition": [2],
@@ -72,6 +74,7 @@ def test_pitstop_logger_writes_stint(tmp_path, monkeypatch):
             self.data = [
                 {
                     "SessionTime": 0,
+                    "SessionNum": 0,
                     "CarIdxOnPitRoad": [False],
                     "CarIdxLap": [1],
                     "CarIdxBestLapTime": [1.1],
@@ -79,6 +82,7 @@ def test_pitstop_logger_writes_stint(tmp_path, monkeypatch):
                 },
                 {
                     "SessionTime": 60,
+                    "SessionNum": 0,
                     "CarIdxOnPitRoad": [True],
                     "CarIdxLap": [2],
                     "CarIdxBestLapTime": [1.1],


### PR DESCRIPTION
## Summary
- automatically move old logs to `RaceLogs/` when the iRacing session changes
- reset logging state for the new session in `ai_standings_logger.py` and `pitstop_logger_enhanced.py`
- update unit tests for new `SessionNum` access
- document automatic log rotation in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684459735300832a992edc2d60b60a8d