### PR TITLE
Fix logging runner lookup for frozen app

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ pip install pyinstaller
 pyinstaller --onefile race_gui.py
 ```
 
+Include the `race_data_runner.py` helper by passing the `--add-data` option.
+On Windows use a semicolon to separate the destination:
+
+```bash
+pyinstaller --onefile --add-data "race_data_runner.py;." race_gui.py
+```
+
+For Linux/macOS replace the semicolon with a colon:
+
+```bash
+pyinstaller --onefile --add-data "race_data_runner.py:." race_gui.py
+```
+
 The resulting `dist/race_gui.exe` can be distributed by itself.  When launched from
 inside the `dist` folder it looks for `race_data_runner.py` in the parent directory
 (the project root), so keep the default folder structure or adjust the path in

--- a/race_gui.py
+++ b/race_gui.py
@@ -509,12 +509,21 @@ class RaceLoggerGUI:
             import race_data_runner as _runner_mod
             runner = Path(_runner_mod.__file__).resolve()
         except Exception:
-            runner = Path(__file__).resolve().parent / "race_data_runner.py"
+            base = Path(__file__).resolve().parent
+            runner = base / "race_data_runner.py"
             if not runner.exists():
-                runner = Path(__file__).resolve().parent.parent / "race_data_runner.py"
+                runner = base.parent / "race_data_runner.py"
+            if getattr(sys, "frozen", False) and not runner.exists():
+                runner = Path(sys._MEIPASS) / "race_data_runner.py"
+        if not runner.exists():
+            messagebox.showerror(
+                "Logger",
+                f"race_data_runner.py not found: {runner}",
+            )
+            return
 
         python = _find_python()
-        cmd = [python, str(runner), "--db", str(self.db_path)]
+        cmd = [python, str(runner), "--db", str(self.db_path), "--auto-install"]
         print(f"[INFO] Launching {runner.name} --db {self.db_path}")
         self.proc = subprocess.Popen(
             cmd,


### PR DESCRIPTION
## Summary
- search for `race_data_runner.py` in `sys._MEIPASS` when frozen
- warn if the helper script cannot be located
- pass `--auto-install` to the runner process
- document how to bundle `race_data_runner.py` with PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445e5a9d54832aa1ebd5d55fa05826