### PR TITLE
Add race_data_runner to spec file

### DIFF
--- a/race_gui.spec
+++ b/race_gui.spec
@@ -13,7 +13,7 @@ a = Analysis(
     ['race_gui.py'],
     pathex=[],
     binaries=[(PYTHON_EXE, PYTHON_NAME)],
-    datas=collect_data_files("sv_ttk"),
+    datas=collect_data_files("sv_ttk") + [("race_data_runner.py", ".")],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary
- include `race_data_runner.py` when building `race_gui` with PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844604df6dc832aa8257dfd6069e894