### PR TITLE
Add lap delta logger

### DIFF
--- a/lap_delta_logger.py
+++ b/lap_delta_logger.py
@@ -1,0 +1,115 @@
+"""Log lap-by-lap delta to the leader.
+
+This script connects to iRacing via :mod:`irsdk` and writes a CSV file
+``lap_delta_log.csv`` containing the time difference to the race leader
+whenever a car completes a lap. The delta is calculated using the
+``SessionTime`` at the moment a car's lap counter increments compared to
+the leader's time for the same lap.
+"""
+
+from __future__ import annotations
+
+import csv
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import irsdk
+
+
+CSV_PATH = "lap_delta_log.csv"
+
+HEADER = ["Time", "CarIdx", "Lap", "DeltaToLeader"]
+
+
+def iso_now() -> str:
+    """Return current local time in ISO-8601 format."""
+
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def rollover_log(path: str) -> None:
+    """Move the current log to ``RaceLogs`` with a timestamp."""
+
+    dest_dir = Path("RaceLogs")
+    dest_dir.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    dest = dest_dir / f"{Path(path).stem}_{ts}.csv"
+    try:
+        Path(path).rename(dest)
+    except FileNotFoundError:
+        pass
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerow(HEADER)
+
+
+def log_deltas(csv_path: str) -> None:
+    """Main logging loop."""
+
+    ir = irsdk.IRSDK()
+    ir.startup()
+
+    last_lap: dict[int, int] = {}
+    leader_lap_time: dict[int, float] = {}
+    prev_session = ir["SessionNum"]
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerow(HEADER)
+
+    try:
+        while True:
+            ts = iso_now()
+            session_num = ir["SessionNum"]
+            if session_num != prev_session:
+                rollover_log(csv_path)
+                last_lap.clear()
+                leader_lap_time.clear()
+                prev_session = session_num
+
+            laps = ir["CarIdxLap"]
+            pos = ir["CarIdxPosition"]
+            sess_time = ir["SessionTime"]
+
+            try:
+                leader_idx = pos.index(1)
+            except ValueError:
+                leader_idx = None
+
+            with open(csv_path, "a", newline="", encoding="utf-8") as f:
+                wr = csv.writer(f)
+                for idx, lap in enumerate(laps):
+                    if lap <= 0:
+                        continue
+                    prev = last_lap.get(idx)
+                    if prev is not None and lap == prev:
+                        continue
+                    last_lap[idx] = lap
+
+                    if idx == leader_idx:
+                        leader_lap_time[lap] = sess_time
+                        delta = 0.0
+                    else:
+                        leader_time = leader_lap_time.get(lap)
+                        delta = sess_time - leader_time if leader_time is not None else ""
+
+                    wr.writerow([ts, idx, lap, delta])
+
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Logger stopped by user.")
+    finally:
+        try:
+            ir.shutdown()
+        except Exception:
+            pass
+
+
+def main(path: Optional[str] = None) -> None:
+    csv_path = path or CSV_PATH
+    log_deltas(csv_path)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_lap_delta_logger.py
+++ b/tests/test_lap_delta_logger.py
@@ -1,0 +1,89 @@
+import csv
+import runpy
+import sys
+import types
+import time
+from pathlib import Path
+
+
+def test_lap_delta_logger(tmp_path, monkeypatch):
+    """Ensure lap_delta_logger creates a CSV with lap deltas."""
+
+    class DummyIR:
+        def __init__(self):
+            self.is_initialized = True
+            self.is_connected = True
+            self.idx = 0
+            self.data = [
+                {
+                    "SessionTime": 0,
+                    "SessionNum": 0,
+                    "CarIdxLap": [0, 0],
+                    "CarIdxPosition": [1, 2],
+                    "DriverInfo": {"Drivers": [{}, {}]},
+                },
+                {
+                    "SessionTime": 30,
+                    "SessionNum": 0,
+                    "CarIdxLap": [1, 0],
+                    "CarIdxPosition": [1, 2],
+                    "DriverInfo": {"Drivers": [{}, {}]},
+                },
+                {
+                    "SessionTime": 32,
+                    "SessionNum": 0,
+                    "CarIdxLap": [1, 1],
+                    "CarIdxPosition": [1, 2],
+                    "DriverInfo": {"Drivers": [{}, {}]},
+                },
+                {
+                    "SessionTime": 60,
+                    "SessionNum": 0,
+                    "CarIdxLap": [2, 1],
+                    "CarIdxPosition": [1, 2],
+                    "DriverInfo": {"Drivers": [{}, {}]},
+                },
+                {
+                    "SessionTime": 66,
+                    "SessionNum": 0,
+                    "CarIdxLap": [2, 2],
+                    "CarIdxPosition": [1, 2],
+                    "DriverInfo": {"Drivers": [{}, {}]},
+                },
+            ]
+
+        def startup(self):
+            pass
+
+        def step(self):
+            if self.idx < len(self.data) - 1:
+                self.idx += 1
+
+        def __getitem__(self, key):
+            return self.data[self.idx][key]
+
+    dummy_ir = DummyIR()
+    monkeypatch.setitem(sys.modules, "irsdk", types.SimpleNamespace(IRSDK=lambda: dummy_ir))
+
+    sleep_calls = [0]
+    def fake_sleep(_):
+        sleep_calls[0] += 1
+        dummy_ir.step()
+        if sleep_calls[0] >= 6:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    monkeypatch.setattr(sys, "argv", ["lap_delta_logger.py"])
+    monkeypatch.chdir(tmp_path)
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+    runpy.run_module("lap_delta_logger", run_name="__main__")
+
+    csv_path = tmp_path / "lap_delta_log.csv"
+    rows = list(csv.reader(open(csv_path)))
+    assert rows[0] == ["Time", "CarIdx", "Lap", "DeltaToLeader"]
+    assert rows[1][2:] == ["1", "0.0"]
+    assert rows[2][2:] == ["1", "2"]
+    assert rows[3][2:] == ["2", "0.0"]
+    assert rows[4][2:] == ["2", "6"]
+


### PR DESCRIPTION
## Summary
- log gap to race leader every time a car completes a lap
- test new logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844616f6650832aa8eee6a74426281c