### PR TITLE
Throttle pit-window warnings

### DIFF
--- a/tests/test_estimate_pits.py
+++ b/tests/test_estimate_pits.py
@@ -3,19 +3,20 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from race_gui import estimate_remaining_pits
+import race_gui
 
 
 def test_normal_expected():
     race_end = dt.datetime(2025, 6, 7, 12, 0)
     now = dt.datetime(2025, 6, 7, 10, 0)
-    assert estimate_remaining_pits(race_end, now, 1800) == 4
+    assert race_gui.estimate_remaining_pits(race_end, now, 1800) == 4
 
 
 def test_zero_expected_uses_fallback(caplog):
     race_end = dt.datetime(2025, 6, 7, 12, 0)
     now = dt.datetime(2025, 6, 7, 10, 0)
-    pits = estimate_remaining_pits(race_end, now, 0, fallback=1800)
+    race_gui.LAST_PIT_WARNING = None
+    pits = race_gui.estimate_remaining_pits(race_end, now, 0, fallback=1800)
     assert pits == 4
     assert "expected pit-window duration missing" in caplog.text
 
@@ -23,5 +24,32 @@ def test_zero_expected_uses_fallback(caplog):
 def test_negative_expected_uses_fallback():
     race_end = dt.datetime(2025, 6, 7, 12, 0)
     now = dt.datetime(2025, 6, 7, 10, 0)
-    assert estimate_remaining_pits(race_end, now, -50, fallback=1800) == 4
+    assert race_gui.estimate_remaining_pits(race_end, now, -50, fallback=1800) == 4
+
+
+def test_warning_throttled(caplog):
+    race_end = dt.datetime(2025, 6, 7, 12, 0)
+    start = dt.datetime(2025, 6, 7, 10, 0)
+    race_gui.LAST_PIT_WARNING = None
+
+    race_gui.estimate_remaining_pits(race_end, start, 0, fallback=1800)
+    assert "expected pit-window duration missing" in caplog.text
+
+    caplog.clear()
+    race_gui.estimate_remaining_pits(
+        race_end,
+        start + race_gui.PIT_WARNING_INTERVAL / 2,
+        0,
+        fallback=1800,
+    )
+    assert "expected pit-window duration missing" not in caplog.text
+
+    caplog.clear()
+    race_gui.estimate_remaining_pits(
+        race_end,
+        start + race_gui.PIT_WARNING_INTERVAL * 1.5,
+        0,
+        fallback=1800,
+    )
+    assert "expected pit-window duration missing" in caplog.text
 


### PR DESCRIPTION
## Summary
- throttle the missing pit-window warning in `race_gui`
- test that the warning appears once per interval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844673ab804832ab78194024e4fc7ad