### PR TITLE
Implement version guardrails and locking

### DIFF
--- a/ai_standings_logger.py
+++ b/ai_standings_logger.py
@@ -5,13 +5,30 @@ CSV file.  The output path and polling interval can be configured via
 command line arguments.
 """
 
+from datetime import datetime
+__version__     = "2025.06.07.0"
+__build_time__  = "2025-06-07T15:42:00Z"
+__commit_hash__ = "abc1234"
+
+import sys
+
+if getattr(sys, "frozen", False):
+    try:
+        setattr(sys, "_MEIPASS_VERSION", __version__)
+        setattr(sys, "_MEIPASS_BUILD", __build_time__)
+        setattr(sys, "_MEIPASS_COMMIT", __commit_hash__)
+        if __spec__ is not None:
+            __spec__.origin = f"{__spec__.origin}|{__version__}"
+    except Exception:
+        pass
+
 import argparse
 import csv
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 import shutil
+from codebase_cleaner import check_latest_version
 
 import eec_db
 
@@ -178,6 +195,11 @@ def parse_args() -> argparse.Namespace:
         "--db",
         help="SQLite database path",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"EEC Logger v{__version__} (build {__build_time__}, git {__commit_hash__})",
+    )
     args, _ = parser.parse_known_args()
     return args
 
@@ -188,4 +210,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    import threading
+    threading.Thread(target=check_latest_version, args=(__version__,), daemon=True).start()
     main()

--- a/lap_delta_logger.py
+++ b/lap_delta_logger.py
@@ -8,12 +8,30 @@ the leader's time for the same lap.
 """
 
 from __future__ import annotations
+from datetime import datetime
+__version__     = "2025.06.07.0"
+__build_time__  = "2025-06-07T15:42:00Z"
+__commit_hash__ = "abc1234"
+
+import sys
+import argparse
+
+if getattr(sys, "frozen", False):
+    try:
+        setattr(sys, "_MEIPASS_VERSION", __version__)
+        setattr(sys, "_MEIPASS_BUILD", __build_time__)
+        setattr(sys, "_MEIPASS_COMMIT", __commit_hash__)
+        if __spec__ is not None:
+            __spec__.origin = f"{__spec__.origin}|{__version__}"
+    except Exception:
+        pass
 
 import csv
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+from codebase_cleaner import check_latest_version
 
 import irsdk
 
@@ -105,11 +123,26 @@ def log_deltas(csv_path: str) -> None:
             pass
 
 
-def main(path: Optional[str] = None) -> None:
-    csv_path = path or CSV_PATH
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Lap delta logger")
+    parser.add_argument("--output", default=CSV_PATH, help="CSV output file")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"EEC Logger v{__version__} (build {__build_time__}, git {__commit_hash__})",
+    )
+    args, _ = parser.parse_known_args(argv)
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    csv_path = args.output
     log_deltas(csv_path)
 
 
 if __name__ == "__main__":
+    import threading
+    threading.Thread(target=check_latest_version, args=(__version__,), daemon=True).start()
     main()
 

--- a/pitstop_logger_enhanced.py
+++ b/pitstop_logger_enhanced.py
@@ -1,14 +1,31 @@
+from datetime import datetime
+__version__     = "2025.06.07.0"
+__build_time__  = "2025-06-07T15:42:00Z"
+__commit_hash__ = "abc1234"
+
+import sys
+
+if getattr(sys, "frozen", False):
+    try:
+        setattr(sys, "_MEIPASS_VERSION", __version__)
+        setattr(sys, "_MEIPASS_BUILD", __build_time__)
+        setattr(sys, "_MEIPASS_COMMIT", __commit_hash__)
+        if __spec__ is not None:
+            __spec__.origin = f"{__spec__.origin}|{__version__}"
+    except Exception:
+        pass
+
 import argparse
 import irsdk, csv, time
 import shutil
 from pathlib import Path
+from codebase_cleaner import check_latest_version
 
 import eec_db
 try:
     import pandas as pd
 except Exception:
     pd = None
-from datetime import datetime
 
 CSV_FILE     = "pitstop_log.csv"
 OVERLAY_FILE = "live_standings_overlay.html"
@@ -101,11 +118,18 @@ def parse_args() -> argparse.Namespace:
         "--driver-total", default=DRIVER_TOTAL_FILE, help="Driver totals CSV"
     )
     parser.add_argument("--db", help="SQLite database path")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"EEC Logger v{__version__} (build {__build_time__}, git {__commit_hash__})",
+    )
     args, _ = parser.parse_known_args()
     return args
 
 
 args = parse_args()
+import threading
+threading.Thread(target=check_latest_version, args=(__version__,), daemon=True).start()
 CSV_FILE = args.output
 DRIVER_TOTAL_FILE = args.driver_total
 DB_PATH = args.db
@@ -309,3 +333,7 @@ while True:
         break
 if conn:
     conn.close()
+
+if __name__ == "__main__":
+    import threading
+    threading.Thread(target=check_latest_version, args=(__version__,), daemon=True).start()

--- a/race_data_runner.py
+++ b/race_data_runner.py
@@ -1,4 +1,9 @@
 # race_data_runner.py
+from datetime import datetime
+__version__     = "2025.06.07.0"
+__build_time__  = "2025-06-07T15:42:00Z"
+__commit_hash__ = "abc1234"
+
 import argparse
 import subprocess
 import signal
@@ -8,8 +13,18 @@ import os
 import threading
 import csv
 from pathlib import Path
-from datetime import datetime
 from typing import Any
+from codebase_cleaner import check_latest_version
+
+if getattr(sys, "frozen", False):
+    try:
+        setattr(sys, "_MEIPASS_VERSION", __version__)
+        setattr(sys, "_MEIPASS_BUILD", __build_time__)
+        setattr(sys, "_MEIPASS_COMMIT", __commit_hash__)
+        if __spec__ is not None:
+            __spec__.origin = f"{__spec__.origin}|{__version__}"
+    except Exception:
+        pass
 
 # Ensure all relative paths resolve to the project directory
 if getattr(sys, "frozen", False):
@@ -27,6 +42,11 @@ def parse_args() -> argparse.Namespace:
         "--auto-install",
         action="store_true",
         help="Automatically install missing dependencies",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"EEC Logger v{__version__} (build {__build_time__}, git {__commit_hash__})",
     )
     args, _ = parser.parse_known_args()
     return args
@@ -326,4 +346,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    import threading
+    threading.Thread(target=check_latest_version, args=(__version__,), daemon=True).start()
     sys.exit(main())

--- a/race_gui.py
+++ b/race_gui.py
@@ -1,3 +1,20 @@
+from datetime import datetime
+__version__     = "2025.06.07.0"         # auto-bump in CI
+__build_time__  = "2025-06-07T15:42:00Z" # auto-fill in CI
+__commit_hash__ = "abc1234"              # git rev-parse --short HEAD
+
+import sys
+
+if getattr(sys, "frozen", False):
+    try:
+        setattr(sys, "_MEIPASS_VERSION", __version__)
+        setattr(sys, "_MEIPASS_BUILD", __build_time__)
+        setattr(sys, "_MEIPASS_COMMIT", __commit_hash__)
+        if __spec__ is not None:
+            __spec__.origin = f"{__spec__.origin}|{__version__}"
+    except Exception:
+        pass
+
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog, simpledialog
 from tkinter.scrolledtext import ScrolledText
@@ -8,10 +25,17 @@ import time
 import select
 import os
 import shutil
-import sys
 from pathlib import Path
 from queue import Queue, Empty
 from collections import deque
+
+VERSION_DONE = threading.Event()
+VERSION_OK = False
+
+def _run_version_check() -> None:
+    global VERSION_OK
+    VERSION_OK = check_latest_version(__version__)
+    VERSION_DONE.set()
 import csv
 import re
 import json
@@ -22,6 +46,11 @@ import logging
 import atexit
 import platform
 import traceback
+from codebase_cleaner import (
+    check_latest_version,
+    acquire_single_instance_lock,
+    focus_running_window,
+)
 
 import eec_teams
 import importlib
@@ -253,7 +282,7 @@ def _find_python() -> str:
 class RaceLoggerGUI:
     def __init__(self, root: tk.Tk, *, classic_theme: bool = False, time_left: float | None = None):
         self.root = root
-        self.root.title("EEC Logger")
+        self.root.title(f"EEC Logger • v{__version__} • {__commit_hash__}")
         # Ensure the window is large enough when it first appears
         self.root.minsize(800, 600)
         if hasattr(self.root, "geometry"):
@@ -321,6 +350,9 @@ class RaceLoggerGUI:
             frm, text="Start Logging", command=self.start_logging
         )
         self.start_btn.grid(column=0, row=1, pady=5, sticky="ew")
+        if not VERSION_DONE.is_set() or not VERSION_OK:
+            self.start_btn.config(state="disabled")
+            self.root.after(200, self._check_version_ready)
         self.stop_btn = ttk.Button(
             frm, text="Stop Logging", command=self.stop_logging, state="disabled"
         )
@@ -671,6 +703,13 @@ class RaceLoggerGUI:
             if os.path.exists(f):
                 shutil.copy(f, target)
         messagebox.showinfo("Saved", f"Logs copied to {target}")
+
+    def _check_version_ready(self) -> None:
+        if VERSION_DONE.is_set():
+            if VERSION_OK:
+                self.start_btn.config(state="normal")
+            return
+        self.root.after(200, self._check_version_ready)
 
     def update_wrap(self) -> None:
         wrap = tk.WORD if self.wrap_logs.get() else tk.NONE
@@ -1869,6 +1908,11 @@ def parse_cli(argv: list[str] | None = None) -> argparse.Namespace:
         type=_parse_time,
         help="remaining race time (H:M:S or seconds)",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"EEC Logger v{__version__} (build {__build_time__}, git {__commit_hash__})",
+    )
 
     args, unknown = parser.parse_known_args(argv)
     global _UNKNOWN_ARGS
@@ -2068,6 +2112,12 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    import threading
+    threading.Thread(target=_run_version_check, daemon=True).start()
+    lock = acquire_single_instance_lock()
+    if lock is None:
+        focus_running_window()
+        sys.exit(0)
     try:
         sys.exit(main())
     except RuntimeError as exc:  # pragma: no cover - early failures

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai  # optional for ChatGPT export via race_gui.py
 sv_ttk   # modern theme for the Tkinter GUI
 
 watchfiles>=0.21.0
+packaging

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,68 @@
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import codebase_cleaner
+
+
+class DummyResp:
+    def __init__(self, data: dict):
+        self._data = json.dumps(data).encode()
+    def read(self):
+        return self._data
+    def __enter__(self):
+        return self
+    def __exit__(self, *exc):
+        pass
+
+def test_unsupported_version_exit(monkeypatch):
+    monkeypatch.setattr(
+        codebase_cleaner.urllib.request,
+        "urlopen",
+        lambda *a, **k: DummyResp({"latest": "2", "min_supported": "1.5"}),
+    )
+    monkeypatch.setattr(codebase_cleaner.messagebox, "showerror", lambda *a, **k: None)
+    with pytest.raises(SystemExit) as exc:
+        codebase_cleaner.check_latest_version("1")
+    assert exc.value.code == 20
+
+
+def test_update_available_returns_false(monkeypatch):
+    monkeypatch.setattr(
+        codebase_cleaner.urllib.request,
+        "urlopen",
+        lambda *a, **k: DummyResp({"latest": "2", "min_supported": "1"}),
+    )
+    monkeypatch.setattr(codebase_cleaner.messagebox, "showinfo", lambda *a, **k: None)
+    assert codebase_cleaner.check_latest_version("1.5") is False
+
+
+def test_network_error_returns_true(monkeypatch):
+    def boom(*a, **k):
+        raise codebase_cleaner.urllib.error.URLError("fail")
+    monkeypatch.setattr(codebase_cleaner.urllib.request, "urlopen", boom)
+    assert codebase_cleaner.check_latest_version("1") is True
+
+
+def test_single_instance(monkeypatch, tmp_path):
+    env = os.environ.copy()
+    env["EEC_DUMMY_TK"] = "1"
+    env["LOCALAPPDATA"] = str(tmp_path)
+    script = Path(__file__).resolve().parents[1] / "race_gui.py"
+    p1 = subprocess.Popen([sys.executable, str(script)], env=env)
+    time.sleep(0.5)
+    p2 = subprocess.Popen([sys.executable, str(script)], env=env)
+    time.sleep(0.5)
+    running = sum(p.poll() is None for p in (p1, p2))
+    for p in (p1, p2):
+        if p.poll() is None:
+            p.terminate()
+            p.wait()
+    assert running == 1


### PR DESCRIPTION
## Summary
- embed build metadata in all entry scripts
- add version checking and single-instance lock utilities
- integrate version guardrails in GUI and CLI tools
- add `--version` handling via argparse built-in version action
- add tests for version checking and single instance lock
- add `packaging` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684469175954832a83faaf26cb04a193