### PR TITLE
Slow GUI_HEARTBEAT to once every 60 seconds

### DIFF
--- a/race_gui.py
+++ b/race_gui.py
@@ -1985,7 +1985,8 @@ def start_heartbeat(start_event: threading.Event) -> None:
         # cleared before the thread gets scheduled again.
         print("GUI_HEARTBEAT", flush=True)
         while start_event.is_set():
-            time.sleep(2)
+            # Delay between heartbeats to reduce log noise
+            time.sleep(60)
             if not start_event.is_set():
                 break
             print("GUI_HEARTBEAT", flush=True)


### PR DESCRIPTION
## Summary
- lengthen the GUI heartbeat interval to 60 seconds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446e12cab8832a9f382d2cdc298417