### PR TITLE
Disable unfinished features in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ dependencies from `requirements.txt`:
 ```
 
 
-The optional `openai` package can be installed afterwards if you plan to
-use the ChatGPT export feature in the GUI.
 
 After activating the environment install the project in editable mode so the
 command line entry points are available:
@@ -74,7 +72,7 @@ This creates CSV log files in the repository directory and writes console output
 Logos and spec maps under `Logos/` and `SpecMaps/` contain the Final Fantasy XIV themed assets used for the championship.
 
 ## GUI
-A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  Tabs are available to view the `driver_swaps.csv` and `standings_log.csv` files directly, while buttons open the `pitstop_log.csv`, `driver_times.csv` and `series_standings.csv` logs in their own windows.  The driver time view allows filtering by team and sorting by clicking the column headers.  If the optional `openai` package is installed and an `OPENAI_API_KEY` environment variable is set, the GUI can send the logs to ChatGPT and store the resulting analysis in a text file.  A **Live Race Feed** tab displays the latest overtakes, pit stops, driver swaps, fastest laps and penalties and refreshes automatically. A **View Live Feed…** button opens a new window showing the latest overtakes, pit stops, driver swaps, fastest laps and penalties which refreshes automatically.
+A basic Tkinter interface is provided in `race_gui.py`.  It lets you start and stop the logging utilities, shows the current iRacing connection status and has buttons to reset or save the log files.  Tabs are available to view the `driver_swaps.csv` and `standings_log.csv` files directly, while buttons open the `pitstop_log.csv`, `driver_times.csv` and `series_standings.csv` logs in their own windows.  The driver time view allows filtering by team and sorting by clicking the column headers.  A **Live Race Feed** tab displays the latest overtakes, pit stops, driver swaps, fastest laps and penalties and refreshes automatically. A **View Live Feed…** button opens a new window showing the latest overtakes, pit stops, driver swaps, fastest laps and penalties which refreshes automatically.
 The window also provides a simple *File* menu with a *Quit* action to close the application. A modern dark theme from the `sv_ttk` package is applied and the `Logos/App/EECApp.png` image will be used as the window icon when available. Ensure `sv_ttk` is installed for the modern look – the GUI attempts to install it automatically when missing.
 
 Run it with:

--- a/build/race_gui/warn-race_gui.txt
+++ b/build/race_gui/warn-race_gui.txt
@@ -22,7 +22,6 @@ missing module named pwd - imported by posixpath (delayed, conditional, optional
 missing module named 'collections.abc' - imported by traceback (top-level), typing (top-level), inspect (top-level), logging (top-level), importlib.resources.readers (top-level), selectors (top-level), tracemalloc (top-level), yaml.constructor (top-level), http.client (top-level)
 missing module named posix - imported by os (conditional, optional), posixpath (optional), shutil (conditional), importlib._bootstrap_external (conditional)
 missing module named resource - imported by posix (top-level)
-missing module named openai - imported by C:\Users\Redux\Documents\EEC\race_gui.py (optional)
 missing module named grp - imported by shutil (delayed, optional), tarfile (optional), pathlib._local (optional), subprocess (delayed, conditional, optional)
 missing module named _posixsubprocess - imported by subprocess (conditional)
 missing module named fcntl - imported by subprocess (optional)

--- a/build/race_gui/xref-race_gui.html
+++ b/build/race_gui/xref-race_gui.html
@@ -193,7 +193,6 @@ imports:
  &#8226;   <a href="#linecache">linecache</a>
  &#8226;   <a href="#locale">locale</a>
  &#8226;   <a href="#ntpath">ntpath</a>
- &#8226;   <a href="#openai">openai</a>
  &#8226;   <a href="#operator">operator</a>
  &#8226;   <a href="#os">os</a>
  &#8226;   <a href="#pathlib">pathlib</a>
@@ -6336,13 +6335,6 @@ imported by:
   </div>
 
 </div>
-
-<div class="node">
-  <a name="openai"></a>
-  <a target="code" href="" type="text/plain"><tt>openai</tt></a>
-<span class="moduletype">MissingModule</span>  <div class="import">
-imported by:
-    <a href="#race_gui.py">race_gui.py</a>
 
   </div>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pandas
 colorama
 pyirsdk
-openai  # optional for ChatGPT export via race_gui.py
 sv_ttk   # modern theme for the Tkinter GUI
 
 watchfiles>=0.21.0

--- a/tests/test_parse_cli.py
+++ b/tests/test_parse_cli.py
@@ -16,12 +16,12 @@ def _ns(**kwargs) -> argparse.Namespace:
 
 
 def test_parse_cli_defaults():
-    assert parse_cli([]) == _ns(debug=False, debug_shell=False, classic_theme=False, no_openai=False, db="eec_log.db", time_left=None)
+    assert parse_cli([]) == _ns(debug=False, debug_shell=False, classic_theme=False, db="eec_log.db", time_left=None)
 
 
 def test_parse_cli_all_flags():
-    args = ["--debug", "--debug-shell", "--classic-theme", "--no-openai", "--db", "foo.db", "--time-left", "1:00:00"]
-    assert parse_cli(args) == _ns(debug=True, debug_shell=True, classic_theme=True, no_openai=True, db="foo.db", time_left=3600)
+    args = ["--debug", "--debug-shell", "--classic-theme", "--db", "foo.db", "--time-left", "1:00:00"]
+    assert parse_cli(args) == _ns(debug=True, debug_shell=True, classic_theme=True, db="foo.db", time_left=3600)
 
 
 def test_parse_cli_bug_repro():
@@ -30,4 +30,4 @@ def test_parse_cli_bug_repro():
 
 def test_parse_cli_mixed_unknown():
     ns = parse_cli(["--debug", "--foo", "extra.txt", "--db", "bar.db"])
-    assert ns == _ns(debug=True, debug_shell=False, classic_theme=False, no_openai=False, db="bar.db", time_left=None)
+    assert ns == _ns(debug=True, debug_shell=False, classic_theme=False, db="bar.db", time_left=None)

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -84,33 +84,3 @@ def test_theme_fallback(monkeypatch, tmp_path):
     assert 'theme default' in log_path.read_text()
 
 
-def test_disable_openai(monkeypatch, tmp_path):
-    logger, log_path = make_logger(tmp_path)
-
-    class DummyRoot:
-        def after(self, _delay, func):
-            func()
-        def mainloop(self):
-            pass
-        def deiconify(self):
-            pass
-        def lift(self):
-            pass
-        def update_idletasks(self):
-            pass
-        def winfo_ismapped(self):
-            return True
-        def update(self):
-            pass
-
-    def make_root():
-        root = DummyRoot()
-        race_gui.tk._default_root = root
-        return root
-
-    monkeypatch.setattr(race_gui.tk, '_default_root', None)
-    monkeypatch.setattr(race_gui.tk, 'Tk', make_root)
-    monkeypatch.setattr(race_gui, 'RaceLoggerGUI', lambda *_a, **_k: types.SimpleNamespace(theme='default'))
-    code = race_gui.main(['--no-openai'])
-    assert code == 0
-    assert 'OpenAI disabled' in log_path.read_text()


### PR DESCRIPTION
## Summary
- strip unstable ChatGPT export and related CLI flag
- drop network version check and keep dummy GUI alive for tests
- remove optional dependency from requirements
- update README and tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447116dfe0832a81b18ea6e46db2b0